### PR TITLE
refactor(project): move all skill artifacts under .project/{slug}/

### DIFF
--- a/docs/codex-skills/project.md
+++ b/docs/codex-skills/project.md
@@ -26,7 +26,7 @@ The normal flow is:
 
 1. `$project` bootstraps `progress.txt` or reports current project status.
 2. `$project-define` performs Codebase Alignment, optional Working Backwards, and Scope Review.
-3. `$project-design` creates or refreshes `docs/ARCHITECTURE_AND_DESIGN.md`.
+3. `$project-design` creates or refreshes `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md`.
 4. `$project-milestone` defines the next milestone and milestone status file.
 5. `$project-plan-feature` creates an implementation plan for one feature.
 6. `$project-build` implements the approved plan sub-feature by sub-feature.
@@ -38,12 +38,12 @@ The normal flow is:
 
 | Gate | Owned By | Meaning | Typical Artifact |
 |---|---|---|---|
-| Gate 0: Codebase Alignment | `$project-define` | Brownfield codebase assessment, or skipped for greenfield projects | `docs/codebase-assessment.md` |
-| Gate WB: Working Backwards | `$project-define` and `$project` state decisions | Optional customer-outcome exercise | `docs/working-backwards.md` |
+| Gate 0: Codebase Alignment | `$project-define` | Brownfield codebase assessment, or skipped for greenfield projects | `.project/{slug}/docs/codebase-assessment.md` |
+| Gate WB: Working Backwards | `$project-define` and `$project` state decisions | Optional customer-outcome exercise | `.project/{slug}/docs/working-backwards.md` |
 | Gate 1: Scope Review | `$project-define` | Approved PRD | `prd.md` |
-| Gate 2: Design Review | `$project-design` | Approved architecture and design | `docs/ARCHITECTURE_AND_DESIGN.md` |
-| Gate 3: Milestone Review | `$project-milestone`, closed by `$project` | Milestone sequence and one or more approved milestones | `milestones/<NN>-<name>/README.md` |
-| Gate 4: Feature Planning | `$project-plan-feature` | One approved implementation plan | `milestones/<NN>-<name>/plans/<feature>.md` |
+| Gate 2: Design Review | `$project-design` | Approved architecture and design | `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` |
+| Gate 3: Milestone Review | `$project-milestone`, closed by `$project` | Milestone sequence and one or more approved milestones | `.project/{slug}/milestones/<NN>-<name>/README.md` |
+| Gate 4: Feature Planning | `$project-plan-feature` | One approved implementation plan | `.project/{slug}/milestones/<NN>-<name>/plans/<feature>.md` |
 
 Gate 4 is represented in milestone status rather than the top-level `progress.txt` gate list. A feature marked `[~] planned, awaiting build` is ready for `$project-build`.
 
@@ -57,6 +57,7 @@ The bootstrap shape is:
 
 ```text
 # Progress: <Project Name>
+# Project-ID: <slug>
 # Created: <ISO date>
 # Status: [ ] pending  [~] in progress  [x] complete  [-] skipped
 
@@ -85,7 +86,7 @@ For greenfield projects, Gate 0 is recorded as:
 
 ### `milestone-status.txt`
 
-Each milestone has a detailed status file at `milestones/<NN>-<name>/milestone-status.txt`. It tracks feature status, plan paths, sub-feature counts, and notes:
+Each milestone has a detailed status file at `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt`. It tracks feature status, plan paths, sub-feature counts, and notes:
 
 ```text
 # Milestone 01: Core Auth
@@ -94,13 +95,46 @@ Each milestone has a detailed status file at `milestones/<NN>-<name>/milestone-s
 ## Features
 
 [x] Feature 01.1: User Registration
-    Plan: milestones/01-core-auth/plans/user-registration.md
+    Plan: .project/{slug}/milestones/01-core-auth/plans/user-registration.md
     Sub-features: 3/3 complete
 
 [~] Feature 01.2: Session Management
-    Plan: milestones/01-core-auth/plans/session-management.md
+    Plan: .project/{slug}/milestones/01-core-auth/plans/session-management.md
     Sub-features: 1/4 complete
 ```
+
+### Output Artifact Layout
+
+All generated documentation and milestone artifacts are grouped under `.project/{slug}/`. `progress.txt` and `prd.md` remain at the project root.
+
+```
+progress.txt                            (project root)
+prd.md                                  (project root)
+
+.project/{slug}/
+  docs/
+    codebase-assessment.md             ($project-define, Gate 0)
+    working-backwards.md               ($project-define, Gate WB)
+    ARCHITECTURE_AND_DESIGN.md         ($project-design, Gate 2)
+    spikes/
+      {topic}.md                       ($project-spike)
+    reviews/
+      gate-0-review.md
+      gate-wb-review.md
+      gate-1-review.md
+      gate-2-review.md
+  milestones/
+    {NN}-{name}/
+      README.md                        ($project-milestone)
+      milestone-status.txt             ($project-milestone, $project-build)
+      plans/
+        {feature}.md                   ($project-plan-feature, $project-build)
+      reviews/
+        gate-3-review.md
+        gate-4-{feature}-review.md
+```
+
+The `Project-ID` slug is set during bootstrap and stored in `progress.txt` as `# Project-ID: <slug>`. Every skill reads this header to derive the base path at runtime — no path is hardcoded in any skill.
 
 ### Status Markers
 
@@ -125,7 +159,7 @@ The suite is designed around conservative state writes:
 - `$project-milestone` writes milestone artifacts and updates `progress.txt`.
 - `$project-plan-feature` writes only the active `milestone-status.txt`.
 - `$project-build` updates `milestone-status.txt` first, then `progress.txt`.
-- `$project-spike` writes or updates `docs/spikes/<topic>.md` and spike entries in `progress.txt`.
+- `$project-spike` writes or updates `.project/{slug}/docs/spikes/<topic>.md` and spike entries in `progress.txt`.
 
 When both milestone-level and project-level state change, `milestone-status.txt` is written first. This preserves the detailed source of truth and lets `$project` detect any divergence during the next status read.
 
@@ -176,19 +210,19 @@ Routing is first-match based on `references/routing-logic.md`. Key decisions inc
 
 Modes:
 
-- Brownfield: creates `docs/codebase-assessment.md` for Gate 0.
+- Brownfield: creates `.project/{slug}/docs/codebase-assessment.md` for Gate 0.
 - Greenfield: records Gate 0 as skipped.
 - Gate WB resume: resolves a previously deferred Working Backwards decision.
 - PRD revision: revises an approved `prd.md` when project goals change.
 
 Outputs:
 
-- `docs/codebase-assessment.md`
-- `docs/working-backwards.md` when Gate WB is accepted
+- `.project/{slug}/docs/codebase-assessment.md`
+- `.project/{slug}/docs/working-backwards.md` when Gate WB is accepted
 - `prd.md`
-- `docs/reviews/gate-0-review.md`
-- `docs/reviews/gate-wb-review.md`
-- `docs/reviews/gate-1-review.md`
+- `.project/{slug}/docs/reviews/gate-0-review.md`
+- `.project/{slug}/docs/reviews/gate-wb-review.md`
+- `.project/{slug}/docs/reviews/gate-1-review.md`
 
 Each gate uses a produce-then-review pattern. Approval is recorded only after checklist items are marked `[x]` or `[-]` with a reason.
 
@@ -196,14 +230,14 @@ Each gate uses a produce-then-review pattern. Approval is recorded only after ch
 
 `$project-design` owns Gate 2. It requires Gate 1 approval.
 
-Normal mode creates `docs/ARCHITECTURE_AND_DESIGN.md` from the PRD and available context using `assets/architecture-template.md`.
+Normal mode creates `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` from the PRD and available context using `assets/architecture-template.md`.
 
 Refresh mode applies when Gate 2 is already approved or the user asks to refresh architecture. The skill scans feature plans for recorded architectural deviations, asks which deviations to consolidate, and updates the architecture document without overwriting existing content unless approved.
 
 Outputs:
 
-- `docs/ARCHITECTURE_AND_DESIGN.md`
-- `docs/reviews/gate-2-review.md`
+- `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md`
+- `.project/{slug}/docs/reviews/gate-2-review.md`
 - Updated Gate 2 entry in `progress.txt`
 
 ## `$project-milestone`
@@ -214,8 +248,8 @@ On first invocation, it proposes the full milestone sequence and writes the appr
 
 Outputs:
 
-- `milestones/<NN>-<name>/README.md`
-- `milestones/<NN>-<name>/milestone-status.txt`
+- `.project/{slug}/milestones/<NN>-<name>/README.md`
+- `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt`
 - Gate 3 review file
 - Updated Gate 3 and milestone summary entries in `progress.txt`
 
@@ -229,7 +263,7 @@ The skill chooses the first pending feature in the active milestone unless the u
 
 Outputs:
 
-- `milestones/<NN>-<name>/plans/<feature>.md`
+- `.project/{slug}/milestones/<NN>-<name>/plans/<feature>.md`
 - Gate 4 review file
 - Updated feature entry marked `[~] planned, awaiting build`
 
@@ -252,13 +286,13 @@ Outputs include code changes, commits, status updates, test results, and any rec
 
 ## `$project-spike`
 
-`$project-spike` handles technical research. It requires a bootstrapped project and writes spike artifacts under `docs/spikes/`.
+`$project-spike` handles technical research. It requires a bootstrapped project and writes spike artifacts under `.project/{slug}/docs/spikes/`.
 
 The skill intentionally separates research and red-team review into different Codex sub-agent contexts. If isolated sub-agent delegation is unavailable, the skill stops rather than collapsing the two passes into one local context.
 
 Outputs:
 
-- `docs/spikes/<topic>.md`
+- `.project/{slug}/docs/spikes/<topic>.md`
 - New or updated spike entries in `progress.txt`
 - Dated follow-up entries when revisiting an existing spike
 
@@ -266,7 +300,7 @@ Resolved spikes remain in `progress.txt` for auditability.
 
 ## Review Checklists
 
-Definition, design, milestone, and feature planning gates use review checklist files under `docs/reviews/`. Checklists combine static gate requirements with content-specific review items.
+Definition, design, milestone, and feature planning gates use review checklist files under `.project/{slug}/docs/reviews/`. Checklists combine static gate requirements with content-specific review items.
 
 Approval requires every checklist item to be:
 

--- a/docs/codex-skills/project.md
+++ b/docs/codex-skills/project.md
@@ -57,8 +57,8 @@ The bootstrap shape is:
 
 ```text
 # Progress: <Project Name>
-# Project-ID: <slug>
 # Created: <ISO date>
+# Project-ID: <slug>
 # Status: [ ] pending  [~] in progress  [x] complete  [-] skipped
 
 ## Gates

--- a/docs/project-skill-refactor/ARCHITECTURE_AND_DESIGN.md
+++ b/docs/project-skill-refactor/ARCHITECTURE_AND_DESIGN.md
@@ -1,0 +1,152 @@
+# Architecture and Design: Project Skill Path Refactor
+
+## Overview
+
+This document covers the design of a refactor to the `skills/project/` suite. The suite consists of seven skill files (`/project`, `/define`, `/design`, `/milestone`, `/plan-feature`, `/build`, `/spike`) and their associated reference files. Each skill currently writes generated artifacts directly to `docs/` and `milestones/` at the project root.
+
+The refactor moves all generated docs and milestone artifacts under a `.project/{project-id}/` subdirectory while leaving `prd.md` and `progress.txt` at the project root. A slugified project identifier is stored as a new header line in `progress.txt`, giving every skill a single place to read it at runtime. No shared runtime or library is involved — each skill is a standalone markdown prompt that operates independently.
+
+## Component Diagram
+
+```
+skills/project/
+├── SKILL.md                     (/project orchestrator — bootstrap + routing)
+├── references/
+│   ├── progress-format.md       ← ADD Project-ID header spec
+│   ├── routing-logic.md         ← UPDATE path examples
+│   └── status-report-format.md  ← UPDATE path examples
+├── define/
+│   ├── SKILL.md                 ← UPDATE output paths
+│   └── references/
+│       └── progress-format.md   ← UPDATE path examples
+├── design/
+│   ├── SKILL.md                 ← UPDATE output paths
+│   └── references/
+│       └── progress-format.md   ← UPDATE path examples
+├── milestone/
+│   ├── SKILL.md                 ← UPDATE output paths
+│   └── references/
+│       └── progress-format.md   ← UPDATE path examples
+├── plan-feature/
+│   ├── SKILL.md                 ← UPDATE output paths
+│   └── references/
+│       └── progress-format.md   ← UPDATE path examples
+├── build/
+│   ├── SKILL.md                 ← UPDATE output paths
+│   └── references/
+│       └── progress-format.md   ← UPDATE path examples
+└── spike/
+    ├── SKILL.md                 ← UPDATE output paths
+    └── references/
+        └── progress-format.md   ← UPDATE path examples
+```
+
+## Data Flow
+
+Path derivation at skill invocation (applies to all 7 skills):
+
+1. Skill reads `progress.txt` from project root.
+2. Skill parses `# Project-ID: <slug>` from the header section.
+3. Skill constructs base path: `.project/<slug>/`.
+4. All artifact reads and writes resolve against the base path.
+5. Completion report displays paths using the computed base.
+
+Bootstrap flow (`/project`, first run only):
+
+1. `/project` detects no `progress.txt` exists.
+2. Derives a candidate slug from the directory name or user input.
+3. Presents candidate slug via `AskUserQuestion` — user confirms or overrides.
+4. Writes `progress.txt` with the new `# Project-ID:` header line.
+
+## Component Inventory
+
+| # | Component | Type | Purpose |
+|---|-----------|------|---------|
+| 1 | `skills/project/SKILL.md` | Skill prompt | Orchestrator — bootstrap, routing, Gate 3 closure |
+| 2 | `skills/project/references/progress-format.md` | Reference doc | Specifies `progress.txt` format including new Project-ID header |
+| 3 | `skills/project/references/routing-logic.md` | Reference doc | Routing table — path examples updated |
+| 4 | `skills/project/references/status-report-format.md` | Reference doc | Status display format — path examples updated |
+| 5 | `skills/project/define/SKILL.md` | Skill prompt | Gates 0, WB, 1 — docs path updated |
+| 6 | `skills/project/define/references/progress-format.md` | Reference doc | Path examples for define outputs |
+| 7 | `skills/project/design/SKILL.md` | Skill prompt | Gate 2 — docs path updated |
+| 8 | `skills/project/design/references/progress-format.md` | Reference doc | Path examples for design outputs |
+| 9 | `skills/project/milestone/SKILL.md` | Skill prompt | Gate 3 — milestones path updated |
+| 10 | `skills/project/milestone/references/progress-format.md` | Reference doc | Path examples for milestone outputs |
+| 11 | `skills/project/plan-feature/SKILL.md` | Skill prompt | Gate 4 — plans path updated |
+| 12 | `skills/project/plan-feature/references/progress-format.md` | Reference doc | Path examples for plan outputs |
+| 13 | `skills/project/build/SKILL.md` | Skill prompt | Implementation — all artifact paths updated |
+| 14 | `skills/project/build/references/progress-format.md` | Reference doc | Path examples for build outputs |
+| 15 | `skills/project/spike/SKILL.md` | Skill prompt | Spike research — spikes path updated |
+| 16 | `skills/project/spike/references/progress-format.md` | Reference doc | Path examples for spike outputs |
+| 17 | `docs/skills/project.md` | Catalog doc | Suite documentation — output paths updated |
+
+## File Organization
+
+```
+<project-root>/
+├── progress.txt                          # Gates, milestones, spikes (root — unchanged)
+├── prd.md                                # Product requirements (root — unchanged)
+└── .project/
+    └── {project-id}/
+        ├── docs/
+        │   ├── codebase-assessment.md    # /define Gate 0
+        │   ├── working-backwards.md      # /define Gate WB (optional)
+        │   ├── ARCHITECTURE_AND_DESIGN.md # /design Gate 2
+        │   ├── spikes/
+        │   │   └── {slug}.md             # /spike
+        │   └── reviews/
+        │       ├── gate-0-review.md
+        │       ├── gate-wb-review.md
+        │       ├── gate-1-review.md
+        │       └── gate-2-review.md
+        └── milestones/
+            └── {NN}-{name}/
+                ├── README.md             # /milestone
+                ├── milestone-status.txt  # /milestone, /build
+                ├── plans/
+                │   └── {feature-slug}.md # /plan-feature, /build
+                └── reviews/
+                    ├── gate-3-review.md
+                    └── gate-4-{feature-slug}-review.md
+```
+
+## Design Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Store `Project-ID` as a header comment in `progress.txt`, not a separate file | All skills already read `progress.txt` at invocation. Adding one header line avoids a new file dependency with no additional complexity. |
+| 2 | Use a dot-prefixed directory (`.project/`) | Hidden by default in most file browsers and `ls` output, reducing visual clutter. Conventional for tooling-owned metadata. |
+| 3 | Use a slugified identifier for the directory name, not the raw project name | Avoids path issues with spaces and special characters. Slug is derived deterministically from the project name. |
+| 4 | Propose slug to user via `AskUserQuestion` at bootstrap rather than inferring silently | The project-id is permanent once set (changing it would invalidate all stored paths in `progress.txt`). User confirmation prevents accidental misnames. |
+| 5 | `prd.md` and `progress.txt` remain at the project root | These are the two entry points developers interact with directly. Hiding them under `.project/` would obscure them. |
+| 6 | Each skill derives the base path independently; no shared resolution function | The skill suite has no shared runtime — each skill is a standalone prompt. A shared helper would require a new architectural layer out of scope for this refactor. |
+| 7 | Slug format: lowercase, hyphens, alphanumeric only | Simple, unambiguous, safe for all OS file systems. Matches convention used in existing milestone directory names (`01-core-auth`). |
+| 8 | `.project/` committed to version control, not gitignored | Project planning artifacts (PRDs, architecture docs, milestone plans) are meaningful team resources. They belong in the repo history alongside the code they describe. |
+| 9 | No migration tooling for existing projects | This is a breaking change. In-place migration of an existing `docs/` + `milestones/` layout is complex and error-prone. Document the break; existing projects start fresh or migrate manually. |
+| 10 | `references/progress-format.md` updated in each sub-skill independently | Each sub-skill directory has its own copy. Centralizing would require restructuring the reference directory layout — out of scope. |
+| 11 | Artifact paths stored in `progress.txt` use the full `.project/{slug}/...` relative path | Absolute paths would break on repo clone. Paths relative to project root are portable and match the existing convention. |
+| 12 | `.project/{slug}/docs/` and `.project/{slug}/milestones/` created on first write | No bootstrap step creates empty directories. Each skill creates its output directory as needed, same as the current behavior. |
+
+## Dependency Graph
+
+Feature execution order respects the dependency between bootstrap (Feature 1) and path routing (Feature 2), which must be complete before any skill-specific updates are made. Skill updates (Features 3–7) are independent of each other.
+
+```
+Feature 1: Bootstrap (progress.txt + Project-ID)
+    └── Feature 2: Path Routing Infrastructure
+            ├── Feature 3: /define paths
+            ├── Feature 4: /design paths
+            ├── Feature 5: /milestone + /plan-feature paths
+            ├── Feature 6: /build paths
+            └── Feature 7: /spike paths
+                    └── Feature 8: Documentation Update
+```
+
+## Out of Scope
+
+| Item | Rationale |
+|------|-----------|
+| Multi-project support (multiple `.project/` subdirectories in one repo) | Motivation is cleaner root, not concurrent projects. Multi-project use is a natural future extension. |
+| Migration tooling for existing projects | Complexity exceeds value for a prompt-engineering refactor. Manual migration or fresh start is the documented path. |
+| Shared path-resolution utility | No shared runtime exists in the skill suite architecture. Out of scope. |
+| Skill renaming, new gates, or routing changes | Structural and behavioral changes are out of scope per PRD non-goals. |

--- a/docs/skills/build.md
+++ b/docs/skills/build.md
@@ -30,7 +30,7 @@ Reads `progress.txt` from the project root and finds the active milestone (first
 
 ### 2. Codebase Assessment Refresh
 
-Before reading the feature plan, performs an incremental refresh of `docs/codebase-assessment.md`. Uses `git log` to find the last assessment update date, then identifies all files changed since then. If no files have changed, skips the refresh. Otherwise, spawns a sub-agent to read only the changed files and update the relevant assessment sections (Recent Changes, File Organization, Detected Patterns, Dependency Graph, Assumptions, Patterns to Deviate From). The refresh produces a standalone commit before any implementation begins.
+Before reading the feature plan, performs an incremental refresh of `.project/{slug}/docs/codebase-assessment.md`. Uses `git log` to find the last assessment update date, then identifies all files changed since then. If no files have changed, skips the refresh. Otherwise, spawns a sub-agent to read only the changed files and update the relevant assessment sections (Recent Changes, File Organization, Detected Patterns, Dependency Graph, Assumptions, Patterns to Deviate From). The refresh produces a standalone commit before any implementation begins.
 
 ### 3. Sub-Feature Execution
 
@@ -45,7 +45,7 @@ Loads the feature plan from the path recorded in `milestone-status.txt`. Parses 
 
 ### 4. Deviation Recording
 
-During implementation, watches for contradictions between the code being written and what the feature plan or `docs/ARCHITECTURE_AND_DESIGN.md` specifies. When a deviation is detected, pauses implementation and presents the deviation to the user with context on what was planned vs. what changed. The user confirms (Record) or dismisses the deviation. Confirmed deviations are written immediately to the feature plan's `## Architectural Deviations` section as a structured 4-field entry: What changed, Originally planned, Why necessary, Impact. After 3+ deviations, suggests running `/design` in refresh mode.
+During implementation, watches for contradictions between the code being written and what the feature plan or `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` specifies. When a deviation is detected, pauses implementation and presents the deviation to the user with context on what was planned vs. what changed. The user confirms (Record) or dismisses the deviation. Confirmed deviations are written immediately to the feature plan's `## Architectural Deviations` section as a structured 4-field entry: What changed, Originally planned, Why necessary, Impact. After 3+ deviations, suggests running `/design` in refresh mode.
 
 ### 5. Feature Completion
 
@@ -59,10 +59,10 @@ The feature plan checklist is the continuity mechanism. Each completed sub-featu
 
 | Artifact | Path | Created By |
 |----------|------|------------|
-| Updated feature plan | `milestones/<NN>-<name>/plans/<feature-slug>.md` | /build (marks sub-features, records deviations) |
-| milestone-status.txt | `milestones/<NN>-<name>/milestone-status.txt` | /build (updates sub-feature counts, marks completion) |
+| Updated feature plan | `.project/{slug}/milestones/<NN>-<name>/plans/<feature-slug>.md` | /build (marks sub-features, records deviations) |
+| milestone-status.txt | `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt` | /build (updates sub-feature counts, marks completion) |
 | progress.txt | `progress.txt` | /build (increments feature counts, marks milestone completion) |
-| Codebase assessment | `docs/codebase-assessment.md` | /build (incremental refresh via sub-agent) |
+| Codebase assessment | `.project/{slug}/docs/codebase-assessment.md` | /build (incremental refresh via sub-agent) |
 | Sub-feature commits | Git history | /build (one commit per sub-feature) |
 
 ## Skill Files

--- a/docs/skills/define.md
+++ b/docs/skills/define.md
@@ -36,15 +36,15 @@ On invocation, `/define` reads `progress.txt` and determines the entry mode:
 
 ### 2. Gate 0: Codebase Assessment (brownfield only)
 
-Spawns a sub-agent to scan 20-40 codebase files, synthesizes findings into `docs/codebase-assessment.md` with sections covering project overview, file organization, detected patterns, dependency graph, assumptions, patterns to deviate from, open questions, and recent changes. User reviews and can revise before approval.
+Spawns a sub-agent to scan 20-40 codebase files, synthesizes findings into `.project/{slug}/docs/codebase-assessment.md` with sections covering project overview, file organization, detected patterns, dependency graph, assumptions, patterns to deviate from, open questions, and recent changes. User reviews and can revise before approval.
 
 ### 3. Gate WB: Working Backwards (optional)
 
-Offers the user a Working Backwards exercise with three options: proceed, skip, or defer. When accepted, conducts a 3-round interview (customer/problem, solution/experience, internal feasibility) and produces `docs/working-backwards.md` with Press Release, External FAQ, and Internal FAQ sections.
+Offers the user a Working Backwards exercise with three options: proceed, skip, or defer. When accepted, conducts a 3-round interview (customer/problem, solution/experience, internal feasibility) and produces `.project/{slug}/docs/working-backwards.md` with Press Release, External FAQ, and Internal FAQ sections.
 
 ### 4. Gate 1: Scope Review (PRD)
 
-Silently re-reads `docs/codebase-assessment.md` from disk to mitigate context rot. If Working Backwards was completed, reads that document as context (does not auto-populate PRD sections). Conducts a 5-round interview covering Scope, Inputs/Outputs, Security, Operational concerns, and Milestone Scoping. Produces `prd.md` using an adapted template (no Architecture or Features sections -- those are handled by /design and /milestone respectively).
+Silently re-reads `.project/{slug}/docs/codebase-assessment.md` from disk to mitigate context rot. If Working Backwards was completed, reads that document as context (does not auto-populate PRD sections). Conducts a 5-round interview covering Scope, Inputs/Outputs, Security, Operational concerns, and Milestone Scoping. Produces `prd.md` using an adapted template (no Architecture or Features sections -- those are handled by /design and /milestone respectively).
 
 Supports partial approval: user can approve individual PRD sections while requesting revision on others. Sections are independently approvalable via a checklist.
 
@@ -54,7 +54,7 @@ When invoked on a project with an existing approved PRD, reads the current `prd.
 
 ### Review Checklists
 
-Each gate produces a review checklist file at `docs/reviews/gate-{0,wb,1}-review.md`. Checklists combine gate-specific static items with auto-generated content-specific items. All items must be resolved (`[x]` verified or `[-]` N/A with reason) before gate approval is recorded.
+Each gate produces a review checklist file at `.project/{slug}/docs/reviews/gate-{0,wb,1}-review.md`. Checklists combine gate-specific static items with auto-generated content-specific items. All items must be resolved (`[x]` verified or `[-]` N/A with reason) before gate approval is recorded.
 
 ## Artifacts
 
@@ -62,15 +62,15 @@ Each gate produces a review checklist file at `docs/reviews/gate-{0,wb,1}-review
 |------|-----------|------|
 | `progress.txt` | Read | Every invocation (mode detection) |
 | `progress.txt` | Write | Gate 0, WB, and 1 approval recording |
-| `docs/codebase-assessment.md` | Write | Gate 0 (brownfield) |
-| `docs/codebase-assessment.md` | Read | Gate 1 start (context refresh, DEF-16) |
-| `docs/working-backwards.md` | Write | Gate WB (when approved) |
-| `docs/working-backwards.md` | Read | Gate 1 start (context, when exists) |
+| `.project/{slug}/docs/codebase-assessment.md` | Write | Gate 0 (brownfield) |
+| `.project/{slug}/docs/codebase-assessment.md` | Read | Gate 1 start (context refresh, DEF-16) |
+| `.project/{slug}/docs/working-backwards.md` | Write | Gate WB (when approved) |
+| `.project/{slug}/docs/working-backwards.md` | Read | Gate 1 start (context, when exists) |
 | `prd.md` | Write | Gate 1 |
 | `prd.md` | Read | Revision mode |
-| `docs/reviews/gate-0-review.md` | Write | Gate 0 checklist |
-| `docs/reviews/gate-wb-review.md` | Write | Gate WB checklist |
-| `docs/reviews/gate-1-review.md` | Write | Gate 1 checklist |
+| `.project/{slug}/docs/reviews/gate-0-review.md` | Write | Gate 0 checklist |
+| `.project/{slug}/docs/reviews/gate-wb-review.md` | Write | Gate WB checklist |
+| `.project/{slug}/docs/reviews/gate-1-review.md` | Write | Gate 1 checklist |
 
 ## Skill Files
 

--- a/docs/skills/design.md
+++ b/docs/skills/design.md
@@ -6,7 +6,7 @@
 
 ## Purpose
 
-Architecture and design specification skill that produces `docs/ARCHITECTURE_AND_DESIGN.md` from an approved PRD and optional codebase assessment. Uses an agent-based deep codebase scan (15-30 files through an architecture lens) to inform design decisions. Supports section-by-section partial approval with tradeoff callouts before the approval checklist. Gate 2 approval is recorded in `progress.txt`. Refresh mode consolidates accumulated architectural deviations from feature plans into an updated architecture document.
+Architecture and design specification skill that produces `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` from an approved PRD and optional codebase assessment. Uses an agent-based deep codebase scan (15-30 files through an architecture lens) to inform design decisions. Supports section-by-section partial approval with tradeoff callouts before the approval checklist. Gate 2 approval is recorded in `progress.txt`. Refresh mode consolidates accumulated architectural deviations from feature plans into an updated architecture document.
 
 ## When to Use
 
@@ -37,19 +37,19 @@ On invocation, `/design` reads `progress.txt` and determines entry mode:
 
 ### 2. Architecture Generation (Normal Mode)
 
-Reads `prd.md` and `docs/codebase-assessment.md` (if exists). Spawns an architecture sub-agent to scan 15-30 files focusing on component boundaries, data flow patterns, interface contracts, and technology choices. Always spawns the agent, even on greenfield projects.
+Reads `prd.md` and `.project/{slug}/docs/codebase-assessment.md` (if exists). Spawns an architecture sub-agent to scan 15-30 files focusing on component boundaries, data flow patterns, interface contracts, and technology choices. Always spawns the agent, even on greenfield projects.
 
-**If `docs/ARCHITECTURE_AND_DESIGN.md` does not exist:** Creates the document from scratch using the template with 6 sections: Design Decisions (numbered table), Component Inventory, Data Flow, File Organization, Deployment & Operations, Security Considerations.
+**If `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` does not exist:** Creates the document from scratch using the template with 6 sections: Design Decisions (numbered table), Component Inventory, Data Flow, File Organization, Deployment & Operations, Security Considerations.
 
-**If `docs/ARCHITECTURE_AND_DESIGN.md` already exists:** Treats the existing document as authoritative and integrates new content into it. Preserves all existing entries, adds new design decisions and components identified from the PRD and scan, and uses the Edit tool (not Write) to avoid overwriting prior content. Contradictions with the current PRD are surfaced as tradeoff callouts for user review.
+**If `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` already exists:** Treats the existing document as authoritative and integrates new content into it. Preserves all existing entries, adds new design decisions and components identified from the PRD and scan, and uses the Edit tool (not Write) to avoid overwriting prior content. Contradictions with the current PRD are surfaced as tradeoff callouts for user review.
 
 ### 3. Design Review
 
-Presents the full architecture document, then calls out 2-4 design decisions with the most significant tradeoffs. Offers three review options: Approve (proceed to checklist), Revise (focused changes), or Partial Approve (section-by-section checklist where unchecked sections get focused revision). Generates `docs/reviews/gate-2-review.md` with static checklist items plus content-specific auto-generated items. All items must be resolved before gate approval.
+Presents the full architecture document, then calls out 2-4 design decisions with the most significant tradeoffs. Offers three review options: Approve (proceed to checklist), Revise (focused changes), or Partial Approve (section-by-section checklist where unchecked sections get focused revision). Generates `.project/{slug}/docs/reviews/gate-2-review.md` with static checklist items plus content-specific auto-generated items. All items must be resolved before gate approval.
 
 ### 4. Refresh Mode
 
-Scans `milestones/*/plans/*.md` for Architectural Deviations sections. If zero deviations found, reports the doc is current and exits. Otherwise presents each deviation with its original design decision, lets the user select which to consolidate via multiSelect, applies changes, and presents the updated doc for section-by-section review.
+Scans `.project/{slug}/milestones/*/plans/*.md` for Architectural Deviations sections. If zero deviations found, reports the doc is current and exits. Otherwise presents each deviation with its original design decision, lets the user select which to consolidate via multiSelect, applies changes, and presents the updated doc for section-by-section review.
 
 ### 5. Completion Report
 
@@ -59,8 +59,8 @@ Displays summary of artifacts created/updated and suggests next step (`/mileston
 
 | File | Purpose | Gate |
 |------|---------|------|
-| `docs/ARCHITECTURE_AND_DESIGN.md` | System-level architecture and design specification | Gate 2 |
-| `docs/reviews/gate-2-review.md` | Design review checklist for offline reviewers | Gate 2 |
+| `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` | System-level architecture and design specification | Gate 2 |
+| `.project/{slug}/docs/reviews/gate-2-review.md` | Design review checklist for offline reviewers | Gate 2 |
 | `progress.txt` (updated) | Gate 2 approval entry with date and artifact path | Gate 2 |
 
 ## Skill Files
@@ -82,7 +82,7 @@ skills/project/design/
 | Skill | Relationship |
 |-------|-------------|
 | `/project` | Reads `progress.txt` to route users to `/design` when Gate 1 is approved |
-| `/define` | Produces `prd.md` and `docs/codebase-assessment.md` that `/design` reads as inputs |
-| `/milestone` | Consumes `docs/ARCHITECTURE_AND_DESIGN.md` as input for milestone planning |
-| `/plan-feature` | Consumes `docs/ARCHITECTURE_AND_DESIGN.md` for feature implementation plans |
+| `/define` | Produces `prd.md` and `.project/{slug}/docs/codebase-assessment.md` that `/design` reads as inputs |
+| `/milestone` | Consumes `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` as input for milestone planning |
+| `/plan-feature` | Consumes `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` for feature implementation plans |
 | `/build` | Records architectural deviations that `/design` refresh mode consolidates |

--- a/docs/skills/milestone.md
+++ b/docs/skills/milestone.md
@@ -38,7 +38,7 @@ On invocation, `/milestone` reads `progress.txt` and `prd.md` to determine entry
 
 ### 2. First Invocation: Milestone Plan
 
-Reads `prd.md` and `docs/ARCHITECTURE_AND_DESIGN.md`. Proposes full milestone breakdown with sequence numbers, names, summaries, and ordering rationale. Calls out 2-3 key tradeoffs in grouping/ordering decisions. After approval, persists the plan in `prd.md` Milestones section and defines milestone #1.
+Reads `prd.md` and `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md`. Proposes full milestone breakdown with sequence numbers, names, summaries, and ordering rationale. Calls out 2-3 key tradeoffs in grouping/ordering decisions. After approval, persists the plan in `prd.md` Milestones section and defines milestone #1.
 
 ### 3. Subsequent Invocation
 
@@ -46,7 +46,7 @@ Reads the approved milestone plan from `prd.md`. Auto-selects the next milestone
 
 ### 4. Milestone Definition
 
-For each milestone: generates `README.md` (goal, features with acceptance criteria, dependencies, ordering, sizing, definition of done), `milestone-status.txt` (features at pending status), and `reviews/gate-3-review.md` (checklist with DD-13 static items plus auto-generated content items). Updates `progress.txt` with milestone summary line and Gate 3 as in-progress. Presents for review with Approve/Revise/Partial options.
+For each milestone: generates `.project/{slug}/milestones/<NN>-<name>/README.md` (goal, features with acceptance criteria, dependencies, ordering, sizing, definition of done), `milestone-status.txt` (features at pending status), and `reviews/gate-3-review.md` (checklist with DD-13 static items plus auto-generated content items). Updates `progress.txt` with milestone summary line and Gate 3 as in-progress. Presents for review with Approve/Revise/Partial options.
 
 ### 5. Revision Mode
 
@@ -60,9 +60,9 @@ Displays summary of artifacts created/updated, state file changes, and suggests 
 
 | File | Purpose | Gate |
 |------|---------|------|
-| `milestones/<NN>-<name>/README.md` | Milestone feature breakdown with acceptance criteria | Gate 3 |
-| `milestones/<NN>-<name>/milestone-status.txt` | Per-feature status tracking | Gate 3 |
-| `milestones/<NN>-<name>/reviews/gate-3-review.md` | Milestone review checklist for offline reviewers | Gate 3 |
+| `.project/{slug}/milestones/<NN>-<name>/README.md` | Milestone feature breakdown with acceptance criteria | Gate 3 |
+| `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt` | Per-feature status tracking | Gate 3 |
+| `.project/{slug}/milestones/<NN>-<name>/reviews/gate-3-review.md` | Milestone review checklist for offline reviewers | Gate 3 |
 | `prd.md` (updated) | Milestones section populated with plan | Gate 3 |
 | `progress.txt` (updated) | Gate 3 in-progress, milestone summary lines | Gate 3 |
 
@@ -86,6 +86,6 @@ skills/project/milestone/
 |-------|-------------|
 | `/project` | Routes users to `/milestone` when Gate 2 is approved; detects Gate 3 closure when all milestones have completed reviews |
 | `/define` | Produces `prd.md` that `/milestone` reads as primary input; `/milestone` updates prd.md Milestones section |
-| `/design` | Produces `docs/ARCHITECTURE_AND_DESIGN.md` that `/milestone` reads as secondary input |
+| `/design` | Produces `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` that `/milestone` reads as secondary input |
 | `/plan-feature` | Consumes milestone `README.md` and `milestone-status.txt` as inputs for feature planning |
 | `/build` | Consumes feature plans produced by `/plan-feature`; updates `milestone-status.txt` on feature completion |

--- a/docs/skills/plan-feature.md
+++ b/docs/skills/plan-feature.md
@@ -37,7 +37,7 @@ On invocation, `/plan-feature` reads `progress.txt` and `milestone-status.txt` t
 
 ### 2. Input Loading and Codebase Scan
 
-Reads milestone README, `prd.md`, `docs/ARCHITECTURE_AND_DESIGN.md`, `progress.txt`, and `milestone-status.txt` as primary inputs. Spawns a sub-agent for a feature-targeted codebase scan (5-15 files relevant to the feature being planned, not architecture-wide). Reads spike artifacts only when the user explicitly references them -- no auto-detection of `docs/spikes/`.
+Reads milestone README, `prd.md`, `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md`, `progress.txt`, and `milestone-status.txt` as primary inputs. Spawns a sub-agent for a feature-targeted codebase scan (5-15 files relevant to the feature being planned, not architecture-wide). Reads spike artifacts only when the user explicitly references them -- no auto-detection of `.project/{slug}/docs/spikes/`.
 
 ### 3. Plan Generation and Review
 
@@ -55,9 +55,9 @@ Updates `milestone-status.txt` with the plan path and `[~] planned, awaiting bui
 
 | Artifact | Path | Created By |
 |----------|------|------------|
-| Feature plan | `milestones/<NN>-<name>/plans/<feature-slug>.md` | /plan-feature |
-| Gate 4 review | `milestones/<NN>-<name>/reviews/gate-4-<feature-slug>-review.md` | /plan-feature |
-| milestone-status.txt | `milestones/<NN>-<name>/milestone-status.txt` | /plan-feature (updates only) |
+| Feature plan | `.project/{slug}/milestones/<NN>-<name>/plans/<feature-slug>.md` | /plan-feature |
+| Gate 4 review | `.project/{slug}/milestones/<NN>-<name>/reviews/gate-4-<feature-slug>-review.md` | /plan-feature |
+| milestone-status.txt | `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt` | /plan-feature (updates only) |
 
 ## Skill Files
 

--- a/docs/skills/project.md
+++ b/docs/skills/project.md
@@ -16,12 +16,12 @@ The Project Codex skills provide a gated project delivery workflow for Codex. Th
 | Skill | Purpose | Primary Outputs |
 |---|---|---|
 | `$project` | Bootstrap `progress.txt`, report status, validate state, and recommend the next skill | `progress.txt` on bootstrap; status report in chat |
-| `$project-define` | Run Codebase Alignment, optional Working Backwards, and Scope Review | `docs/codebase-assessment.md`, `docs/working-backwards.md`, `prd.md`, review files |
-| `$project-design` | Produce or refresh architecture and design documentation | `docs/ARCHITECTURE_AND_DESIGN.md`, Gate 2 review file |
-| `$project-milestone` | Define or revise one milestone at a time | `milestones/<NN>-<name>/README.md`, `milestone-status.txt` |
-| `$project-plan-feature` | Create or revise one feature implementation plan | `milestones/<NN>-<name>/plans/<feature>.md` |
+| `$project-define` | Run Codebase Alignment, optional Working Backwards, and Scope Review | `.project/{slug}/docs/codebase-assessment.md`, `.project/{slug}/docs/working-backwards.md`, `prd.md`, review files |
+| `$project-design` | Produce or refresh architecture and design documentation | `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md`, Gate 2 review file |
+| `$project-milestone` | Define or revise one milestone at a time | `.project/{slug}/milestones/<NN>-<name>/README.md`, `milestone-status.txt` |
+| `$project-plan-feature` | Create or revise one feature implementation plan | `.project/{slug}/milestones/<NN>-<name>/plans/<feature>.md` |
 | `$project-build` | Implement a planned feature sub-feature by sub-feature | Code changes, commits, updated status files, deviation notes when needed |
-| `$project-spike` | Run adversarial technical research and track spike state | `docs/spikes/<topic>.md`, spike entries in `progress.txt` |
+| `$project-spike` | Run adversarial technical research and track spike state | `.project/{slug}/docs/spikes/<topic>.md`, spike entries in `progress.txt` |
 
 ## When to Use
 
@@ -44,7 +44,7 @@ The Project Codex skills provide a gated project delivery workflow for Codex. Th
 
 ## State Model
 
-The suite uses `progress.txt` as the project-level state file and `milestones/*/milestone-status.txt` as per-milestone state. Both use four checkbox markers:
+The suite uses `progress.txt` as the project-level state file and `.project/{slug}/milestones/*/milestone-status.txt` as per-milestone state. Both use four checkbox markers:
 
 | Marker | Meaning |
 |---|---|

--- a/docs/skills/project.md
+++ b/docs/skills/project.md
@@ -18,7 +18,7 @@ The Project Codex skills provide a gated project delivery workflow for Codex. Th
 | `$project` | Bootstrap `progress.txt`, report status, validate state, and recommend the next skill | `progress.txt` on bootstrap; status report in chat |
 | `$project-define` | Run Codebase Alignment, optional Working Backwards, and Scope Review | `.project/{slug}/docs/codebase-assessment.md`, `.project/{slug}/docs/working-backwards.md`, `prd.md`, review files |
 | `$project-design` | Produce or refresh architecture and design documentation | `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md`, Gate 2 review file |
-| `$project-milestone` | Define or revise one milestone at a time | `.project/{slug}/milestones/<NN>-<name>/README.md`, `milestone-status.txt` |
+| `$project-milestone` | Define or revise one milestone at a time | `.project/{slug}/milestones/<NN>-<name>/README.md`, `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt` |
 | `$project-plan-feature` | Create or revise one feature implementation plan | `.project/{slug}/milestones/<NN>-<name>/plans/<feature>.md` |
 | `$project-build` | Implement a planned feature sub-feature by sub-feature | Code changes, commits, updated status files, deviation notes when needed |
 | `$project-spike` | Run adversarial technical research and track spike state | `.project/{slug}/docs/spikes/<topic>.md`, spike entries in `progress.txt` |

--- a/docs/skills/spike.md
+++ b/docs/skills/spike.md
@@ -29,7 +29,7 @@ Adversarial technical research skill that investigates technical questions using
 
 ### 1. Input Gathering and Mode Detection
 
-Reads `progress.txt` from the project root. Gathers the user's research question and available tooling list per SPIKE-01. If provided in the invocation message, uses them directly; otherwise prompts with `AskUserQuestion`. Generates a topic slug (kebab-case) and checks if `.project/{project-slug}/docs/spikes/<topic>.md` exists. If it exists, enters follow-up mode. If not, enters new spike mode. Slug collisions prompt the user to choose follow-up or new spike with a different name.
+Reads `progress.txt` from the project root. Gathers the user's research question and available tooling list per SPIKE-01. If provided in the invocation message, uses them directly; otherwise prompts with `AskUserQuestion`. Generates a topic slug (kebab-case) and checks if `.project/{slug}/docs/spikes/<topic>.md` exists. If it exists, enters follow-up mode. If not, enters new spike mode. Slug collisions prompt the user to choose follow-up or new spike with a different name.
 
 ### 2. Research Agent
 

--- a/docs/skills/spike.md
+++ b/docs/skills/spike.md
@@ -6,7 +6,7 @@
 
 ## Purpose
 
-Adversarial technical research skill that investigates technical questions using sequential research and red-team agents. Accepts a research question and list of available tooling, produces a structured spike artifact at `docs/spikes/<topic>.md` with both research findings and independent red-team validation. The two perspectives are presented as equal peer sections -- never merged or suppressed. Supports follow-up research on existing spikes with dated append entries. Tracks spike lifecycle in `progress.txt` (open/resolved).
+Adversarial technical research skill that investigates technical questions using sequential research and red-team agents. Accepts a research question and list of available tooling, produces a structured spike artifact at `.project/{slug}/docs/spikes/<topic>.md` with both research findings and independent red-team validation. The two perspectives are presented as equal peer sections -- never merged or suppressed. Supports follow-up research on existing spikes with dated append entries. Tracks spike lifecycle in `progress.txt` (open/resolved).
 
 ## When to Use
 
@@ -29,7 +29,7 @@ Adversarial technical research skill that investigates technical questions using
 
 ### 1. Input Gathering and Mode Detection
 
-Reads `progress.txt` from the project root. Gathers the user's research question and available tooling list per SPIKE-01. If provided in the invocation message, uses them directly; otherwise prompts with `AskUserQuestion`. Generates a topic slug (kebab-case) and checks if `docs/spikes/<slug>.md` exists. If it exists, enters follow-up mode. If not, enters new spike mode. Slug collisions prompt the user to choose follow-up or new spike with a different name.
+Reads `progress.txt` from the project root. Gathers the user's research question and available tooling list per SPIKE-01. If provided in the invocation message, uses them directly; otherwise prompts with `AskUserQuestion`. Generates a topic slug (kebab-case) and checks if `.project/{project-slug}/docs/spikes/<topic>.md` exists. If it exists, enters follow-up mode. If not, enters new spike mode. Slug collisions prompt the user to choose follow-up or new spike with a different name.
 
 ### 2. Research Agent
 
@@ -55,7 +55,7 @@ When the user signals resolution, updates the spike artifact status from `open` 
 
 | Artifact | Path | Created By |
 |----------|------|------------|
-| Spike artifact | `docs/spikes/<topic>.md` | /spike (new spike or follow-up append) |
+| Spike artifact | `.project/{slug}/docs/spikes/<topic>.md` | /spike (new spike or follow-up append) |
 | progress.txt | `progress.txt` | /spike (adds spike entry, marks resolved) |
 
 ## Skill Files

--- a/prd.md
+++ b/prd.md
@@ -6,7 +6,7 @@ Refactor the `skills/project/` skill suite to group all generated documentation 
 
 ## Goals
 
-- Move all generated docs and milestone artifacts under `.project/{project-name}/` to keep the project root clean.
+- Move all generated docs and milestone artifacts under `.project/{slug}/` to keep the project root clean.
 - Store a machine-readable `Project-ID` slug in `progress.txt` so every skill can derive the base path at runtime without hardcoding it.
 - Propose a name to the user at bootstrap and allow override via `AskUserQuestion`.
 - Commit `.project/` to version control alongside the code.
@@ -28,13 +28,13 @@ All skills read `Project-ID` from the `progress.txt` header at invocation time a
 progress.txt (project root)
 prd.md       (project root)
 
-.project/{project-id}/
+.project/{slug}/
   docs/
     codebase-assessment.md      (/define, Gate 0)
     working-backwards.md        (/define, Gate WB)
     ARCHITECTURE_AND_DESIGN.md  (/design, Gate 2)
     spikes/
-      {slug}.md                 (/spike)
+      <topic>.md                (/spike)
     reviews/
       gate-0-review.md
       gate-wb-review.md
@@ -137,7 +137,7 @@ Update `spike/SKILL.md` and `spike/references/progress-format.md` so spike artif
 
 **Acceptance Criteria:**
 
-- `docs/spikes/{slug}.md` → `.project/{project-slug}/docs/spikes/{slug}.md`.
+- `docs/spikes/<topic>.md` → `.project/{slug}/docs/spikes/<topic>.md`.
 - Spike entry in `progress.txt` records the new path.
 - `spike/references/progress-format.md` updated.
 - Completion report shows new path.

--- a/prd.md
+++ b/prd.md
@@ -1,0 +1,177 @@
+# PRD: Project Skill Path Refactor
+
+## Summary
+
+Refactor the `skills/project/` skill suite to group all generated documentation and milestone artifacts under a `.project/{project-name}/` directory in the project root, rather than placing them directly under `docs/` and `milestones/`. The `prd.md` and `progress.txt` files remain at the project root. This keeps the project root uncluttered for developers browsing the repo.
+
+## Goals
+
+- Move all generated docs and milestone artifacts under `.project/{project-name}/` to keep the project root clean.
+- Store a machine-readable `Project-ID` slug in `progress.txt` so every skill can derive the base path at runtime without hardcoding it.
+- Propose a name to the user at bootstrap and allow override via `AskUserQuestion`.
+- Commit `.project/` to version control alongside the code.
+
+## Non-Goals
+
+| Item | Rationale |
+|------|-----------|
+| Skill renaming or re-routing | Out of scope — names, gates, and routing logic unchanged. |
+| State file format changes | `progress.txt` and `milestone-status.txt` structure preserved; only one new header line added. |
+| Multi-project support | Cleaner root is the goal. Multi-project is a natural side effect but is not designed for in this iteration. |
+| Moving `prd.md` or `progress.txt` | Both remain at the project root. |
+
+## Architecture
+
+All skills read `Project-ID` from the `progress.txt` header at invocation time and use it to compute the artifact base path. No path is hardcoded in any skill.
+
+```
+progress.txt (project root)
+prd.md       (project root)
+
+.project/{project-id}/
+  docs/
+    codebase-assessment.md      (/define, Gate 0)
+    working-backwards.md        (/define, Gate WB)
+    ARCHITECTURE_AND_DESIGN.md  (/design, Gate 2)
+    spikes/
+      {slug}.md                 (/spike)
+    reviews/
+      gate-0-review.md
+      gate-wb-review.md
+      gate-1-review.md
+      gate-2-review.md
+  milestones/
+    {NN}-{name}/
+      README.md                 (/milestone)
+      milestone-status.txt      (/milestone, /build)
+      plans/
+        {feature-slug}.md       (/plan-feature, /build)
+      reviews/
+        gate-3-review.md
+        gate-4-{feature-slug}-review.md
+```
+
+Path derivation (all skills):
+1. Read `progress.txt`.
+2. Parse `# Project-ID: <slug>` from the header.
+3. Construct base path: `.project/<slug>/`.
+4. All artifact reads and writes are relative to that base path.
+
+## Features
+
+### Feature 1: Bootstrap — Add Project-ID to progress.txt
+
+Update `/project` bootstrap to capture a slugified project name and write it as a new header line in `progress.txt`. Update `references/progress-format.md` to specify the new header line and slug derivation rules.
+
+**Acceptance Criteria:**
+
+- `progress.txt` bootstrap template gains a `# Project-ID: <slug>` header line between `# Created:` and `# Status:`.
+- Slug is lowercase, hyphen-separated, alphanumeric only (e.g., `My Web App` → `my-web-app`).
+- `/project` bootstrap proposes a derived slug and confirms via `AskUserQuestion` before writing.
+- `references/progress-format.md` documents the new header line, slug format rules, and parsing instruction.
+
+### Feature 2: Path Routing Infrastructure
+
+Update `/project` SKILL.md and its `references/routing-logic.md` and `references/status-report-format.md` to derive and display artifact paths using the `.project/{slug}/` base. Update artifact existence validation to resolve paths against the base.
+
+**Acceptance Criteria:**
+
+- `/project` reads `Project-ID` from `progress.txt` and constructs the base path on every invocation.
+- Status report displays artifact paths as `.project/{slug}/docs/...` and `.project/{slug}/milestones/...`.
+- Artifact validation (PROJ-04) resolves paths from project root using the computed base.
+- `references/routing-logic.md` updated: all path references use `.project/{slug}/` prefix.
+- `references/status-report-format.md` updated: example paths reflect new structure.
+
+### Feature 3: /define Skill Path Updates
+
+Update `define/SKILL.md` and `define/references/progress-format.md` so all artifact writes go to `.project/{slug}/docs/` instead of `docs/`.
+
+**Acceptance Criteria:**
+
+- `docs/codebase-assessment.md` → `.project/{slug}/docs/codebase-assessment.md`.
+- `docs/working-backwards.md` → `.project/{slug}/docs/working-backwards.md`.
+- `docs/reviews/gate-0-review.md` → `.project/{slug}/docs/reviews/gate-0-review.md`.
+- `docs/reviews/gate-wb-review.md` → `.project/{slug}/docs/reviews/gate-wb-review.md`.
+- `docs/reviews/gate-1-review.md` → `.project/{slug}/docs/reviews/gate-1-review.md`.
+- Completion report in `define/SKILL.md` shows `.project/{slug}/` paths.
+- `define/references/progress-format.md` updated with new path examples.
+
+### Feature 4: /design Skill Path Updates
+
+Update `design/SKILL.md` and `design/references/progress-format.md` so all artifact writes go to `.project/{slug}/docs/` instead of `docs/`.
+
+**Acceptance Criteria:**
+
+- `docs/ARCHITECTURE_AND_DESIGN.md` → `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md`.
+- `docs/reviews/gate-2-review.md` → `.project/{slug}/docs/reviews/gate-2-review.md`.
+- Refresh mode scans `milestones/*/plans/*.md` → `.project/{slug}/milestones/*/plans/*.md`.
+- Completion report shows `.project/{slug}/` paths.
+- `design/references/progress-format.md` updated.
+
+### Feature 5: /milestone and /plan-feature Skill Path Updates
+
+Update `milestone/SKILL.md`, `plan-feature/SKILL.md`, and their respective `references/progress-format.md` files so all milestone and plan artifacts write to `.project/{slug}/milestones/` instead of `milestones/`.
+
+**Acceptance Criteria:**
+
+- `milestones/<NN>-<name>/` → `.project/{slug}/milestones/<NN>-<name>/` for all files (README.md, milestone-status.txt, reviews/, plans/).
+- Milestone summary line in `progress.txt` uses `.project/{slug}/milestones/<NN>-<name>/` path.
+- `milestone/references/progress-format.md` and `plan-feature/references/progress-format.md` updated with new path examples.
+- Completion reports in both skills show `.project/{slug}/` paths.
+
+### Feature 6: /build Skill Path Updates
+
+Update `build/SKILL.md` and `build/references/progress-format.md` to read and write artifacts under `.project/{slug}/`.
+
+**Acceptance Criteria:**
+
+- Codebase assessment refresh writes to `.project/{slug}/docs/codebase-assessment.md`.
+- Feature plan files read from `.project/{slug}/milestones/.../plans/`.
+- `milestone-status.txt` read/write uses `.project/{slug}/milestones/...`.
+- `progress.txt` milestone summary line paths match new structure.
+- `build/references/progress-format.md` updated.
+
+### Feature 7: /spike Skill Path Updates
+
+Update `spike/SKILL.md` and `spike/references/progress-format.md` so spike artifacts write to `.project/{slug}/docs/spikes/` instead of `docs/spikes/`.
+
+**Acceptance Criteria:**
+
+- `docs/spikes/{slug}.md` → `.project/{project-slug}/docs/spikes/{slug}.md`.
+- Spike entry in `progress.txt` records the new path.
+- `spike/references/progress-format.md` updated.
+- Completion report shows new path.
+
+### Feature 8: Documentation Update
+
+Update catalog and detail documentation to reflect the new output structure.
+
+**Acceptance Criteria:**
+
+- `docs/skills/project.md` "Primary Outputs" column updated with `.project/{name}/` paths.
+- File tree in documentation reflects new layout.
+- Any other references to `docs/` or `milestones/` as project-skill output paths updated.
+
+## Outputs
+
+| Output | Type | Description |
+|--------|------|-------------|
+| Updated `progress.txt` bootstrap | Template change | Gains `# Project-ID: <slug>` header line |
+| `.project/{slug}/docs/` | Directory | Replaces `docs/` as destination for project skill artifacts |
+| `.project/{slug}/milestones/` | Directory | Replaces `milestones/` as destination for milestone artifacts |
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| Existing projects using old `docs/` and `milestones/` paths will break | This is a breaking change. No migration script is in scope. Users with existing projects need to move artifacts manually or start fresh. Document this in the refactor notes. |
+| Path derivation logic duplicated across 7+ skill files | Each skill reads the same two lines from `progress.txt`. The derivation is simple and consistent; the duplication is intentional (no shared runtime). |
+| Slug collision if two projects produce the same slug | Out of scope for single-project-per-root scenario. Future multi-project support can add collision detection. |
+| `references/progress-format.md` exists independently in each sub-skill directory | Each sub-skill's copy must be updated independently. Feature-per-skill structure ensures none are missed. |
+
+## Success Criteria
+
+- All 8 features pass acceptance criteria.
+- A new project bootstrapped with the refactored suite places all `docs/` and `milestones/` artifacts under `.project/{slug}/` with no artifacts at the old `docs/` or `milestones/` paths.
+- `prd.md` and `progress.txt` remain at the project root.
+- Running `/project` on an updated project correctly displays `.project/{slug}/` paths in the status report and validates artifact existence at those paths.

--- a/progress.txt
+++ b/progress.txt
@@ -11,12 +11,12 @@
     - /project bootstrap proposes slug via AskUserQuestion before writing
     NOTES: Started 2026-05-08  Completed 2026-05-08
 
-[ ] Feature 2: Path Routing Infrastructure
+[x] Feature 2: Path Routing Infrastructure
     - /project reads Project-ID and constructs .project/{slug}/ base path
     - Status report displays .project/{slug}/docs/... and .project/{slug}/milestones/... paths
     - Artifact validation (PROJ-04) resolves paths using computed base
     - routing-logic.md and status-report-format.md updated
-    NOTES:
+    NOTES: Started 2026-05-08  Completed 2026-05-08
 
 [ ] Feature 3: /define Skill Path Updates
     - All docs/ outputs → .project/{slug}/docs/ (codebase-assessment, working-backwards, reviews/)

--- a/progress.txt
+++ b/progress.txt
@@ -23,11 +23,11 @@
     - define/SKILL.md and define/references/progress-format.md updated
     NOTES: Started 2026-05-08  Completed 2026-05-08
 
-[ ] Feature 4: /design Skill Path Updates
+[x] Feature 4: /design Skill Path Updates
     - docs/ARCHITECTURE_AND_DESIGN.md → .project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md
     - Refresh mode scans .project/{slug}/milestones/*/plans/
     - design/SKILL.md and design/references/progress-format.md updated
-    NOTES:
+    NOTES: Started 2026-05-08  Completed 2026-05-08
 
 [ ] Feature 5: /milestone and /plan-feature Skill Path Updates
     - milestones/<NN>-<name>/ → .project/{slug}/milestones/<NN>-<name>/

--- a/progress.txt
+++ b/progress.txt
@@ -1,0 +1,52 @@
+# Progress: Project Skill Path Refactor
+# Source: prd.md + docs/project-skill-refactor/ARCHITECTURE_AND_DESIGN.md
+# Spec: docs/project-skill-refactor/ARCHITECTURE_AND_DESIGN.md is the authoritative design reference
+# Status: [ ] pending  [~] in progress  [x] complete  [-] skipped
+
+## Features
+
+[x] Feature 1: Bootstrap — Add Project-ID to progress.txt
+    - progress.txt bootstrap template gains # Project-ID: <slug> header line
+    - Slug derivation rules specified in references/progress-format.md
+    - /project bootstrap proposes slug via AskUserQuestion before writing
+    NOTES: Started 2026-05-08  Completed 2026-05-08
+
+[ ] Feature 2: Path Routing Infrastructure
+    - /project reads Project-ID and constructs .project/{slug}/ base path
+    - Status report displays .project/{slug}/docs/... and .project/{slug}/milestones/... paths
+    - Artifact validation (PROJ-04) resolves paths using computed base
+    - routing-logic.md and status-report-format.md updated
+    NOTES:
+
+[ ] Feature 3: /define Skill Path Updates
+    - All docs/ outputs → .project/{slug}/docs/ (codebase-assessment, working-backwards, reviews/)
+    - define/SKILL.md and define/references/progress-format.md updated
+    NOTES:
+
+[ ] Feature 4: /design Skill Path Updates
+    - docs/ARCHITECTURE_AND_DESIGN.md → .project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md
+    - Refresh mode scans .project/{slug}/milestones/*/plans/
+    - design/SKILL.md and design/references/progress-format.md updated
+    NOTES:
+
+[ ] Feature 5: /milestone and /plan-feature Skill Path Updates
+    - milestones/<NN>-<name>/ → .project/{slug}/milestones/<NN>-<name>/
+    - milestone-status.txt, plans/, reviews/ all under new base
+    - milestone/SKILL.md, plan-feature/SKILL.md and both progress-format.md refs updated
+    NOTES:
+
+[ ] Feature 6: /build Skill Path Updates
+    - Codebase refresh writes to .project/{slug}/docs/codebase-assessment.md
+    - Feature plans read from .project/{slug}/milestones/.../plans/
+    - build/SKILL.md and build/references/progress-format.md updated
+    NOTES:
+
+[ ] Feature 7: /spike Skill Path Updates
+    - docs/spikes/{slug}.md → .project/{project-slug}/docs/spikes/{slug}.md
+    - spike/SKILL.md and spike/references/progress-format.md updated
+    NOTES:
+
+[ ] Feature 8: Documentation Update
+    - docs/skills/project.md output paths updated to .project/{name}/ structure
+    - File tree in documentation reflects new layout
+    NOTES:

--- a/progress.txt
+++ b/progress.txt
@@ -18,10 +18,10 @@
     - routing-logic.md and status-report-format.md updated
     NOTES: Started 2026-05-08  Completed 2026-05-08
 
-[ ] Feature 3: /define Skill Path Updates
+[x] Feature 3: /define Skill Path Updates
     - All docs/ outputs → .project/{slug}/docs/ (codebase-assessment, working-backwards, reviews/)
     - define/SKILL.md and define/references/progress-format.md updated
-    NOTES:
+    NOTES: Started 2026-05-08  Completed 2026-05-08
 
 [ ] Feature 4: /design Skill Path Updates
     - docs/ARCHITECTURE_AND_DESIGN.md → .project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md

--- a/progress.txt
+++ b/progress.txt
@@ -30,11 +30,11 @@
     - design/SKILL.md and design/references/progress-format.md updated
     NOTES: Started 2026-05-08  Completed 2026-05-08
 
-[ ] Feature 5: /milestone and /plan-feature Skill Path Updates
+[x] Feature 5: /milestone and /plan-feature Skill Path Updates
     - milestones/<NN>-<name>/ → .project/{slug}/milestones/<NN>-<name>/
     - milestone-status.txt, plans/, reviews/ all under new base
     - milestone/SKILL.md, plan-feature/SKILL.md and both progress-format.md refs updated
-    NOTES:
+    NOTES: Started 2026-05-08  Completed 2026-05-08
 
 [ ] Feature 6: /build Skill Path Updates
     - Codebase refresh writes to .project/{slug}/docs/codebase-assessment.md

--- a/progress.txt
+++ b/progress.txt
@@ -1,4 +1,5 @@
 # Progress: Project Skill Path Refactor
+# Project-ID: project-skill-path-refactor
 # Source: prd.md + docs/project-skill-refactor/ARCHITECTURE_AND_DESIGN.md
 # Spec: docs/project-skill-refactor/ARCHITECTURE_AND_DESIGN.md is the authoritative design reference
 # Status: [ ] pending  [~] in progress  [x] complete  [-] skipped

--- a/progress.txt
+++ b/progress.txt
@@ -42,10 +42,10 @@
     - build/SKILL.md and build/references/progress-format.md updated
     NOTES: Started 2026-05-08  Completed 2026-05-08
 
-[ ] Feature 7: /spike Skill Path Updates
+[x] Feature 7: /spike Skill Path Updates
     - docs/spikes/{slug}.md → .project/{project-slug}/docs/spikes/{slug}.md
     - spike/SKILL.md and spike/references/progress-format.md updated
-    NOTES:
+    NOTES: Started 2026-05-08  Completed 2026-05-08
 
 [ ] Feature 8: Documentation Update
     - docs/skills/project.md output paths updated to .project/{name}/ structure

--- a/progress.txt
+++ b/progress.txt
@@ -47,7 +47,7 @@
     - spike/SKILL.md and spike/references/progress-format.md updated
     NOTES: Started 2026-05-08  Completed 2026-05-08
 
-[ ] Feature 8: Documentation Update
+[x] Feature 8: Documentation Update
     - docs/skills/project.md output paths updated to .project/{name}/ structure
     - File tree in documentation reflects new layout
-    NOTES:
+    NOTES: Started 2026-05-08  Completed 2026-05-08

--- a/progress.txt
+++ b/progress.txt
@@ -36,11 +36,11 @@
     - milestone/SKILL.md, plan-feature/SKILL.md and both progress-format.md refs updated
     NOTES: Started 2026-05-08  Completed 2026-05-08
 
-[ ] Feature 6: /build Skill Path Updates
+[x] Feature 6: /build Skill Path Updates
     - Codebase refresh writes to .project/{slug}/docs/codebase-assessment.md
     - Feature plans read from .project/{slug}/milestones/.../plans/
     - build/SKILL.md and build/references/progress-format.md updated
-    NOTES:
+    NOTES: Started 2026-05-08  Completed 2026-05-08
 
 [ ] Feature 7: /spike Skill Path Updates
     - docs/spikes/{slug}.md → .project/{project-slug}/docs/spikes/{slug}.md

--- a/skills/project/SKILL.md
+++ b/skills/project/SKILL.md
@@ -46,17 +46,25 @@ Read `progress.txt` from the project root.
 
 This is the ONLY time `/project` writes to disk.
 
-1. Read `references/progress-format.md` for the exact bootstrap template and format rules.
+1. Read `references/progress-format.md` for the exact bootstrap template, slug derivation
+   rules, and format rules.
 2. Detect greenfield vs brownfield:
    - **Greenfield:** project directory is empty or contains only boilerplate files (README,
      `.gitignore`, `package.json` with no `src/` directory). Use the greenfield variant --
      Gate 0 recorded as `[-] Gate 0: Codebase Alignment  Skipped (greenfield)` (per DD-10).
    - **Brownfield:** existing source code is present. Use the standard template -- Gate 0
      recorded as `[ ] Gate 0: Codebase Alignment`.
-3. Determine the project name: use `AskUserQuestion` to ask the user, or derive from the
-   directory name if the user prefers.
+3. Determine the project name and slug:
+   - Derive a candidate name from the working directory name.
+   - Derive a candidate slug from that name using the slug derivation rules in
+     `references/progress-format.md` (lowercase, hyphens, alphanumeric only).
+   - Use `AskUserQuestion` to confirm or override the name before writing:
+     - Present the derived name and slug as the default option.
+     - Offer the user a chance to provide a custom name; the slug is always re-derived
+       from the name — it is not set independently.
 4. Use the Write tool to create `progress.txt` with the bootstrap template, replacing
-   `<Project Name>` with the project name and `<ISO date>` with today's date (YYYY-MM-DD).
+   `<Project Name>` with the confirmed project name, `<slug>` with the confirmed slug,
+   and `<ISO date>` with today's date (YYYY-MM-DD).
 5. Read the file back and confirm it was created correctly.
 6. Show the user the created file content.
 7. Proceed to Step 3 (Read State) to display the initial status report.

--- a/skills/project/SKILL.md
+++ b/skills/project/SKILL.md
@@ -73,13 +73,16 @@ This is the ONLY time `/project` writes to disk.
 
 Read `progress.txt` from disk (fresh read -- STATE-03). Parse:
 
+- `# Project-ID: <slug>` header line -- derive the artifact base path: `.project/<slug>/`.
+  All artifact reads and writes use this base path for the remainder of the invocation.
 - All gate entries in the `## Gates` section (status marker, name, date, artifact path).
 - All milestone summary lines in the `## Milestones` section (status, name, path, feature
   counts).
 - All spike entries in the `## Spikes` section (status, name, path, resolution date).
 
-For each milestone found, read its `milestone-status.txt` file (path derived from the
-milestone summary line's directory path).
+For each milestone found, read its `milestone-status.txt` at
+`.project/<slug>/milestones/<NN>-<name>/milestone-status.txt` (path derived from the
+milestone summary line's directory path, resolved against the artifact base path).
 
 Read `references/routing-logic.md` for validation rules, then perform:
 
@@ -134,7 +137,8 @@ state using the routing table. Display per D-03:
   current project state).
 
 **Gate WB offer (DD-11, D-08):** If Gate 0 is approved (`[x]`) or skipped (`[-]` greenfield),
-no `docs/working-backwards.md` exists, Gate WB has not been offered yet, and the customer
+no `.project/{slug}/docs/working-backwards.md` exists (where `{slug}` is the value parsed
+from the `# Project-ID:` header), Gate WB has not been offered yet, and the customer
 outcome is unclear -- offer Gate WB using `AskUserQuestion` with options:
 
 - **Yes** -- proceed with Working Backwards exercise (routes to `/define`)

--- a/skills/project/build/SKILL.md
+++ b/skills/project/build/SKILL.md
@@ -46,8 +46,14 @@ from the plan. Updates both `milestone-status.txt` and `progress.txt`.
 
 ## Step 1 -- Detect State and Target Feature
 
-Read `progress.txt` from the project root. Find the active milestone (first
-at `[ ]` or `[~]` status). Read that milestone's `milestone-status.txt`.
+Read `progress.txt` from the project root. Find the line starting with
+`# Project-ID:`, take the value after `:`, trim whitespace, and use it as `<slug>`.
+Construct the artifact base path: `.project/<slug>/`. All artifact reads and writes
+in this skill use this base path. If the header is missing, report the error and tell
+the user to run `/project` to re-bootstrap.
+
+Find the active milestone (first at `[ ]` or `[~]` status). Read that milestone's
+`milestone-status.txt` at `.project/<slug>/milestones/<NN>-<name>/milestone-status.txt`.
 Find the target feature:
 
 - **Auto-detect:** First feature at `[~] planned, awaiting build` status

--- a/skills/project/build/references/build-execution.md
+++ b/skills/project/build/references/build-execution.md
@@ -23,8 +23,8 @@ Stop. Do not proceed.
 override by specifying a feature name.
 
 Extract the `Plan:` path from the selected feature entry (e.g.,
-`milestones/01-core-auth/plans/session-management.md`). This path is required --
-if the plan file does not exist on disk, report the error and stop.
+`.project/{slug}/milestones/01-core-auth/plans/session-management.md`). This path is
+required -- if the plan file does not exist on disk, report the error and stop.
 
 ## Codebase Assessment Refresh (BUILD-02, D-05, D-06, D-07)
 
@@ -68,7 +68,7 @@ Read the sub-feature's description from the plan. Also read:
 - The feature's **Approach** section for implementation strategy
 - The feature's **Interface Contracts** section for signatures and data shapes
 - The feature's **Files to Create/Modify** section for target file paths
-- `docs/ARCHITECTURE_AND_DESIGN.md` for architectural constraints
+- `.project/<slug>/docs/ARCHITECTURE_AND_DESIGN.md` for architectural constraints
 
 ### 2. Implement the Sub-Feature
 
@@ -159,7 +159,7 @@ complete`. Add `Completed: <ISO date>` to the Notes line.
 Before:
 ```
 [~] Feature 01.2: Session Management
-    Plan: milestones/01-core-auth/plans/session-management.md
+    Plan: .project/{slug}/milestones/01-core-auth/plans/session-management.md
     Sub-features: 3/4 complete
     Notes: Started 2026-04-03.
 ```
@@ -167,7 +167,7 @@ Before:
 After:
 ```
 [x] Feature 01.2: Session Management
-    Plan: milestones/01-core-auth/plans/session-management.md
+    Plan: .project/{slug}/milestones/01-core-auth/plans/session-management.md
     Sub-features: 4/4 complete
     Notes: Started 2026-04-03. Completed 2026-04-04.
 ```
@@ -176,14 +176,14 @@ After:
 
 Increment the feature count in the milestone summary line:
 
-Before: `[~] Milestone 01: Core Auth  milestones/01-core-auth/  2/3 features complete`
-After:  `[~] Milestone 01: Core Auth  milestones/01-core-auth/  3/3 features complete`
+Before: `[~] Milestone 01: Core Auth  .project/{slug}/milestones/01-core-auth/  2/3 features complete`
+After:  `[~] Milestone 01: Core Auth  .project/{slug}/milestones/01-core-auth/  3/3 features complete`
 
 **If this was the last feature** (completed count equals total count): also
 change the milestone marker from `[~]` to `[x]` in `progress.txt`:
 
 ```
-[x] Milestone 01: Core Auth  milestones/01-core-auth/  3/3 features complete
+[x] Milestone 01: Core Auth  .project/{slug}/milestones/01-core-auth/  3/3 features complete
 ```
 
 ### Test Fails (non-zero exit code, D-09)

--- a/skills/project/build/references/codebase-refresh.md
+++ b/skills/project/build/references/codebase-refresh.md
@@ -1,8 +1,9 @@
 # Codebase Assessment Refresh Specification
 
-Incremental refresh of `docs/codebase-assessment.md` before feature
+Incremental refresh of `.project/<slug>/docs/codebase-assessment.md` before feature
 implementation begins. An executor reading only this file can run the complete
-refresh flow.
+refresh flow. `<slug>` is the value derived from the `# Project-ID:` header in
+`progress.txt` (established in Step 1 of `SKILL.md`).
 
 ## Timing (D-06, D-07)
 
@@ -22,7 +23,7 @@ codebase state rather than a stale assessment.
 Find when the assessment was last updated:
 
 ```bash
-git log -1 --format="%ai" -- docs/codebase-assessment.md
+git log -1 --format="%ai" -- .project/<slug>/docs/codebase-assessment.md
 ```
 
 This returns the date of the most recent commit that modified the assessment
@@ -68,10 +69,11 @@ Provide the sub-agent with:
 
 1. The list of changed files (from the git log output above)
 2. The feature name being built (for context)
+3. The value of `<slug>` (the Project-ID from `progress.txt`)
 
 Instruct the sub-agent to:
 
-1. **Read `docs/codebase-assessment.md`** -- the current assessment content.
+1. **Read `.project/<slug>/docs/codebase-assessment.md`** -- the current assessment content.
 
 2. **Read only the changed/new files** identified above. Do NOT perform a full
    codebase re-scan. The goal is incremental update, not re-assessment.
@@ -92,8 +94,8 @@ Instruct the sub-agent to:
    sub-agent updates sections, not rewrites the file. Sections unaffected by
    the changes should be left untouched.
 
-5. **Write the updated assessment** back to `docs/codebase-assessment.md` using
-   the Write tool.
+5. **Write the updated assessment** back to `.project/<slug>/docs/codebase-assessment.md`
+   using the Write tool.
 
 ### Sub-Agent Tool Access
 
@@ -109,6 +111,8 @@ any implementation commits:
 docs(assessment): refresh codebase assessment for <feature-name>
 ```
 
+The commit covers `.project/<slug>/docs/codebase-assessment.md`.
+
 This commit is made before loading the feature plan or writing any
 implementation code. It provides a clean separation between "understood the
 codebase" and "started building."
@@ -117,9 +121,9 @@ codebase" and "started building."
 
 ### Assessment File Does Not Exist
 
-If `docs/codebase-assessment.md` does not exist on disk:
+If `.project/<slug>/docs/codebase-assessment.md` does not exist on disk:
 
-> "No codebase assessment found. Run /define to create one."
+> "No codebase assessment found at `.project/<slug>/docs/codebase-assessment.md`. Run /define to create one."
 
 This is a **warning, not a blocker**. `/build` can proceed without an
 assessment, but the user should know their codebase assessment is missing. Skip

--- a/skills/project/build/references/deviation-recording.md
+++ b/skills/project/build/references/deviation-recording.md
@@ -7,7 +7,8 @@ deviation flow -- from detection through confirmation to structured recording.
 ## What Constitutes a Deviation (D-11)
 
 A deviation occurs when the implementation **contradicts** what the feature plan
-or `docs/ARCHITECTURE_AND_DESIGN.md` specifies.
+or `.project/<slug>/docs/ARCHITECTURE_AND_DESIGN.md` specifies. `<slug>` is the
+value derived from the `# Project-ID:` header in `progress.txt`.
 
 ### A deviation IS:
 

--- a/skills/project/build/references/progress-format.md
+++ b/skills/project/build/references/progress-format.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The project pipeline uses plain-text checkbox notation across two tiers of state files: a project-level `progress.txt` at the project root (tracking gate approvals, milestone summaries, and spike entries) and milestone-level `milestone-status.txt` files at `milestones/<NN>-<name>/milestone-status.txt` (tracking per-feature details, sub-feature checklists, and notes). Both files use the same four-marker status notation defined below. This format was chosen over YAML for superior write-safety, token efficiency (~53% fewer tokens), and human editability (see DESIGN.md DD-3, progress-file/TEXT_vs_YAML_REPORT.md).
+The project pipeline uses plain-text checkbox notation across two tiers of state files: a project-level `progress.txt` at the project root (tracking gate approvals, milestone summaries, and spike entries) and milestone-level `milestone-status.txt` files at `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt` (tracking per-feature details, sub-feature checklists, and notes). Both files use the same four-marker status notation defined below. This format was chosen over YAML for superior write-safety, token efficiency (~53% fewer tokens), and human editability (see DESIGN.md DD-3, progress-file/TEXT_vs_YAML_REPORT.md).
 
 ## Status Notation
 
@@ -22,6 +22,7 @@ The exact `progress.txt` content created by `/project` on first run (the only ti
 ```
 # Progress: <Project Name>
 # Created: <ISO date>
+# Project-ID: <slug>
 # Status: [ ] pending  [~] in progress  [x] complete  [-] skipped
 
 ## Gates
@@ -44,8 +45,13 @@ The exact `progress.txt` content created by `/project` on first run (the only ti
 Notes:
 
 - `<Project Name>` is derived from the project directory name or user input at bootstrap time.
+- `<slug>` is the slugified form of the project name (lowercase, hyphens, alphanumeric only).
 - `<ISO date>` is the current date in YYYY-MM-DD format.
 - The `# Status:` header line serves as an inline legend for anyone reading the file.
+
+Parsing instruction for skills: find the line starting with `# Project-ID:`, take the
+value after `:`, trim whitespace, and use it as `<slug>`. Construct the artifact base
+path as `.project/<slug>/`.
 
 ## Greenfield Bootstrap Variant
 
@@ -64,10 +70,13 @@ Gate entries appear in the `## Gates` section, one per line. The format varies b
 **Approved:**
 
 ```
-[x] Gate 0: Codebase Alignment  Approved: 2026-03-15  docs/codebase-assessment.md
+[x] Gate 0: Codebase Alignment  Approved: 2026-03-15  .project/<slug>/docs/codebase-assessment.md
 ```
 
 Format: `[x] Gate N: Name  Approved: <YYYY-MM-DD>  <artifact-path>`
+
+The artifact path is relative to the project root and uses the `.project/<slug>/` base
+path derived from the `# Project-ID: <slug>` header in `progress.txt`.
 
 **Skipped:**
 
@@ -106,10 +115,10 @@ The artifact path on approved entries is the primary deliverable of that gate. `
 One line per milestone in the `## Milestones` section:
 
 ```
-[ ] Milestone 01: Core Auth  milestones/01-core-auth/  0/3 features complete
+[ ] Milestone 01: Core Auth  .project/{slug}/milestones/01-core-auth/  0/3 features complete
 ```
 
-Format: `[status] Milestone NN: Name  milestones/<NN>-<name>/  N/M features complete`
+Format: `[status] Milestone NN: Name  .project/{slug}/milestones/<NN>-<name>/  N/M features complete`
 
 Where:
 
@@ -138,7 +147,7 @@ Format: `[status] Spike Name  <artifact-path>` with an optional `Resolved: <date
 
 ## milestone-status.txt Format
 
-Per-milestone file located at `milestones/<NN>-<name>/milestone-status.txt`. Uses the same checkbox notation as `progress.txt` (per STATE-02). Contains detailed feature tracking for a single milestone.
+Per-milestone file located at `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt`. Uses the same checkbox notation as `progress.txt` (per STATE-02). Contains detailed feature tracking for a single milestone.
 
 ```
 # Milestone 01: Core Auth
@@ -147,11 +156,11 @@ Per-milestone file located at `milestones/<NN>-<name>/milestone-status.txt`. Use
 ## Features
 
 [x] Feature 01.1: User Registration
-    Plan: milestones/01-core-auth/plans/user-registration.md
+    Plan: .project/{slug}/milestones/01-core-auth/plans/user-registration.md
     Sub-features: 3/3 complete
 
 [~] Feature 01.2: Session Management
-    Plan: milestones/01-core-auth/plans/session-management.md
+    Plan: .project/{slug}/milestones/01-core-auth/plans/session-management.md
     Sub-features: 1/4 complete
     Notes: Switched from JWT to session cookies (see architectural deviation)
 

--- a/skills/project/define/SKILL.md
+++ b/skills/project/define/SKILL.md
@@ -42,7 +42,11 @@ one continuous conversation -- the user does not leave between gates.
 
 ## Step 1 -- Detect Mode and State
 
-Read `progress.txt` from the project root.
+Read `progress.txt` from the project root. Find the line starting with
+`# Project-ID:`, take the value after `:`, trim whitespace, and use it as `<slug>`.
+Construct the artifact base path: `.project/<slug>/`. All artifact reads and writes
+in this skill use this base path. If the header is missing, report the error and tell
+the user to run `/project` to re-bootstrap.
 
 **Revision mode detection (DEF-15):**
 Check ALL of the following:
@@ -83,9 +87,9 @@ Read `references/gate-0-codebase.md` for the complete Gate 0 specification.
 
 Follow the gate-0-codebase specification to:
 1. Spawn a sub-agent to scan the codebase (20-40 files).
-2. Synthesize findings into `docs/codebase-assessment.md`.
+2. Synthesize findings into `.project/<slug>/docs/codebase-assessment.md`.
 3. Present findings and enter produce-then-review cycle.
-4. Generate review checklist (`docs/reviews/gate-0-review.md`) using
+4. Generate review checklist (`.project/<slug>/docs/reviews/gate-0-review.md`) using
    `references/review-checklist-template.md`.
 5. Validate checklist completeness before recording approval.
 6. Record Gate 0 approval in `progress.txt` per `references/progress-format.md`.
@@ -106,8 +110,9 @@ Check current Gate WB state in `progress.txt`:
 - If `[ ]` (not yet offered): offer Gate WB per the specification.
 
 Follow the gate-wb specification to handle the 3-outcome offer:
-- **Yes**: run WB interview, produce `docs/working-backwards.md`, review cycle,
-  record approval.
+- **Yes**: run WB interview, produce `.project/<slug>/docs/working-backwards.md`,
+  generate review checklist (`.project/<slug>/docs/reviews/gate-wb-review.md`),
+  review cycle, record approval.
 - **Skip**: record `[-] Gate WB: Working Backwards  Skipped` in `progress.txt`.
   Proceed to Step 5.
 - **Defer**: record `[ ] Gate WB: Working Backwards  Pending -- offered, awaiting
@@ -123,10 +128,10 @@ Proceed to Step 5.
 Read `references/gate-1-prd.md` for the complete Gate 1 specification.
 
 Follow the gate-1 specification to:
-1. Silently re-read `docs/codebase-assessment.md` from disk for context (DEF-16).
-   Do NOT recap or summarize it to the user -- use internally only.
-2. Read `docs/working-backwards.md` if it exists (D-14 -- context only, does not
-   auto-populate PRD sections).
+1. Silently re-read `.project/<slug>/docs/codebase-assessment.md` from disk for
+   context (DEF-16). Do NOT recap or summarize it to the user -- use internally only.
+2. Read `.project/<slug>/docs/working-backwards.md` if it exists (D-14 -- context
+   only, does not auto-populate PRD sections).
 3. Gather the initial project concept (seed the PRD).
 4. Conduct the 5-round interview (Scope, Inputs/Outputs, Security, Operational,
    Milestone Scoping). One round at a time via `AskUserQuestion`.
@@ -135,7 +140,7 @@ Follow the gate-1 specification to:
    Partial Approve).
 7. Handle partial approval if needed (DEF-12 -- section checklist for focused
    revision of unchecked sections).
-8. Generate review checklist (`docs/reviews/gate-1-review.md`) using
+8. Generate review checklist (`.project/<slug>/docs/reviews/gate-1-review.md`) using
    `references/review-checklist-template.md`.
 9. Validate checklist completeness.
 10. Record Gate 1 approval in `progress.txt`.
@@ -146,14 +151,14 @@ Proceed to Step 7 (Completion Report).
 
 Read `references/gate-1-prd.md` for the revision mode specification.
 Read existing `prd.md` from disk.
-Re-read `docs/codebase-assessment.md` from disk if it exists (DEF-16 silent
-re-read -- no recap to user).
+Re-read `.project/<slug>/docs/codebase-assessment.md` from disk if it exists (DEF-16
+silent re-read -- no recap to user).
 
 Follow the revision mode specification to:
 1. Ask "What changed?" -- focused interview on affected sections only.
 2. Revise `prd.md` with edits. Show each change before and after.
 3. Present for review (produce-then-review cycle).
-4. Generate or update review checklist (`docs/reviews/gate-1-review.md`).
+4. Generate or update review checklist (`.project/<slug>/docs/reviews/gate-1-review.md`).
 5. Surface downstream artifact impacts without auto-resetting (DD-6). List
    affected artifacts and ask the user which need re-review.
 6. Record Gate 1 re-approval with updated date in `progress.txt`.
@@ -168,14 +173,14 @@ Display a summary of what was produced:
 DEFINITION COMPLETE: [Project Title]
 
 ARTIFACTS CREATED:
-- docs/codebase-assessment.md (Gate 0) [or "Skipped (greenfield)"]
-- docs/working-backwards.md (Gate WB) [or "Skipped" / "Pending"]
+- .project/<slug>/docs/codebase-assessment.md (Gate 0) [or "Skipped (greenfield)"]
+- .project/<slug>/docs/working-backwards.md (Gate WB) [or "Skipped" / "Pending"]
 - prd.md (Gate 1)
 
 REVIEW CHECKLISTS:
-- docs/reviews/gate-0-review.md [if applicable]
-- docs/reviews/gate-wb-review.md [if applicable]
-- docs/reviews/gate-1-review.md
+- .project/<slug>/docs/reviews/gate-0-review.md [if applicable]
+- .project/<slug>/docs/reviews/gate-wb-review.md [if applicable]
+- .project/<slug>/docs/reviews/gate-1-review.md
 
 NEXT: Run /project to see updated status, then /design for Gate 2.
 ```
@@ -189,6 +194,9 @@ NEXT: Run /project to see updated status, then /design for Gate 2.
 - **Gate 1 already approved without revision intent:** Inform the user that Gate 1
   is already complete. Use `AskUserQuestion` with options: **Revise** (enters
   revision mode) or **Status** (suggests running `/project`).
+- **Missing Project-ID header:** If `progress.txt` exists but has no `# Project-ID:`
+  line, do not proceed. Tell the user to run `/project` to re-bootstrap and add the
+  Project-ID header.
 - **Interrupted session:** If the conversation is interrupted mid-gate, the user
   can re-invoke `/define`. The skill re-reads `progress.txt` and resumes from the
   appropriate gate based on which gates are already approved.

--- a/skills/project/define/references/gate-0-codebase.md
+++ b/skills/project/define/references/gate-0-codebase.md
@@ -2,6 +2,8 @@
 
 Scans the existing codebase and produces a structured assessment for use in subsequent gates. This reference contains the complete Gate 0 specification -- an executor reading only this file can run the full Gate 0 flow.
 
+`{slug}` is read from the `# Project-ID: <slug>` header in `progress.txt` at session start. All artifact paths in this document use `.project/{slug}/` as the base path.
+
 ## Greenfield Detection (DEF-01)
 
 Before running the codebase scan, check whether the project is greenfield. ALL of the following conditions must be true to classify as greenfield and skip Gate 0:
@@ -63,8 +65,8 @@ The agent uses only: `Read`, `Bash` (for `ls`, `git log`), and `Glob` tools.
 After the agent completes, synthesize its findings into the final assessment:
 
 1. Read the agent's scratch file (e.g., `/tmp/codebase-scan-findings.md`)
-2. Create `docs/` directory if it does not exist: `mkdir -p docs`
-3. Write `docs/codebase-assessment.md` with these required sections:
+2. Create `.project/{slug}/docs/` directory if it does not exist: `mkdir -p .project/{slug}/docs`
+3. Write `.project/{slug}/docs/codebase-assessment.md` with these required sections:
 
 ### Required Assessment Sections
 
@@ -96,7 +98,7 @@ Present the assessment to the user using the produce-then-review cycle:
    - **Approve** -- assessment is accurate, proceed to checklist validation
    - **Revise** -- assessment needs corrections
 
-3. **If Revise:** Ask the user what needs changing. Apply edits to `docs/codebase-assessment.md`. Re-present the updated summary. Repeat until the user selects Approve.
+3. **If Revise:** Ask the user what needs changing. Apply edits to `.project/{slug}/docs/codebase-assessment.md`. Re-present the updated summary. Repeat until the user selects Approve.
 
 4. **If Approve:** Proceed to Checklist Validation.
 
@@ -104,14 +106,14 @@ Present the assessment to the user using the produce-then-review cycle:
 
 Generate and validate the review checklist:
 
-1. Create `docs/reviews/` directory if needed: `mkdir -p docs/reviews`
+1. Create `.project/{slug}/docs/reviews/` directory if needed: `mkdir -p .project/{slug}/docs/reviews`
 
-2. Generate `docs/reviews/gate-0-review.md` using the Gate 0 section from `references/review-checklist-template.md`. Start with the file header:
+2. Generate `.project/{slug}/docs/reviews/gate-0-review.md` using the Gate 0 section from `references/review-checklist-template.md`. Start with the file header:
 
    ```
    # Gate 0 Review -- Codebase Alignment
 
-   **Artifact:** docs/codebase-assessment.md
+   **Artifact:** .project/{slug}/docs/codebase-assessment.md
    **Status:** [ ] Pending
    **Reviewer(s):**
    **Date:**
@@ -130,7 +132,7 @@ Generate and validate the review checklist:
    - `[ ] [Auto] Review deviation: "{specific anti-pattern flagged}"`
 
 5. **Claude pre-checks** items it can verify programmatically:
-   - File `docs/codebase-assessment.md` exists
+   - File `.project/{slug}/docs/codebase-assessment.md` exists
    - All required sections are present
    - File paths cited in the assessment exist on disk
 
@@ -152,7 +154,7 @@ Record the gate approval in progress.txt:
    ```
    to:
    ```
-   [x] Gate 0: Codebase Alignment  Approved: <YYYY-MM-DD>  docs/codebase-assessment.md
+   [x] Gate 0: Codebase Alignment  Approved: <YYYY-MM-DD>  .project/{slug}/docs/codebase-assessment.md
    ```
    where `<YYYY-MM-DD>` is the current date.
 

--- a/skills/project/define/references/gate-1-prd.md
+++ b/skills/project/define/references/gate-1-prd.md
@@ -4,12 +4,14 @@ Conducts a structured interview and produces a Product Requirements Document (`p
 
 Gate 1 is the most complex gate in the `/define` skill. It covers the full PRD lifecycle: context loading, multi-round interview, document production, partial approval, checklist validation, gate approval recording, and revision mode for existing PRDs.
 
+`{slug}` is read from the `# Project-ID: <slug>` header in `progress.txt` at session start. All artifact paths in this document use `.project/{slug}/` as the base path.
+
 ## Context Refresh (DEF-16)
 
 At the start of Gate 1, silently re-read context files from disk to mitigate context rot (by this point, Gate 0 and Gate WB conversations may have scrolled out of the context window).
 
-1. **Read `docs/codebase-assessment.md`** from disk (if it exists). Do NOT recap or summarize the assessment to the user -- use it internally as context for the interview.
-2. **Read `docs/working-backwards.md`** from disk (if it exists and Gate WB was approved). Use as context for the interview -- the WB narrative informs better questions and answers, but does NOT auto-populate PRD sections (D-14). The full interview still runs.
+1. **Read `.project/{slug}/docs/codebase-assessment.md`** from disk (if it exists). Do NOT recap or summarize the assessment to the user -- use it internally as context for the interview.
+2. **Read `.project/{slug}/docs/working-backwards.md`** from disk (if it exists and Gate WB was approved). Use as context for the interview -- the WB narrative informs better questions and answers, but does NOT auto-populate PRD sections (D-14). The full interview still runs.
 
 This silent re-read is critical: without it, the PRD interview proceeds without codebase awareness, producing a document that ignores existing patterns and constraints.
 
@@ -133,7 +135,8 @@ When all sections are checked (approved) or the user does a full Approve, procee
 ## Checklist Validation (DEF-04, DEF-06)
 
 1. Read `references/review-checklist-template.md` for the Gate 1 checklist structure
-2. Generate `docs/reviews/gate-1-review.md` using the Gate 1 section from the template
+2. Create `.project/{slug}/docs/reviews/` directory if needed: `mkdir -p .project/{slug}/docs/reviews`
+3. Generate `.project/{slug}/docs/reviews/gate-1-review.md` using the Gate 1 section from the template
 3. Add content-specific `[Auto]` items based on actual PRD content (e.g., verify specific assumptions, confirm specific non-goals are intentional, validate specific risks have mitigations)
 4. Claude pre-checks `[x]` items that can be verified from the PRD content
 5. Present remaining unchecked items to the user for resolution
@@ -159,7 +162,7 @@ Revision mode is triggered when `/define` detects an existing `prd.md` AND the u
 ### Revision Flow
 
 1. **Read existing `prd.md`** from disk
-2. **Context refresh**: Read `docs/codebase-assessment.md` from disk if it exists (same DEF-16 silent re-read -- no recap to user)
+2. **Context refresh**: Read `.project/{slug}/docs/codebase-assessment.md` from disk if it exists (same DEF-16 silent re-read -- no recap to user)
 3. **Ask the user**: "What changed?" -- open-ended question about what prompted the revision. Let the user describe the changes in their own words.
 4. **Focused interview**: Conduct a targeted interview on ONLY the affected sections. Do not re-run the full 5-round interview. Ask clarifying questions specific to the changed areas.
 5. **Update `prd.md`**: Apply revisions using the Edit tool. Show the user each change before and after.
@@ -170,9 +173,9 @@ Revision mode is triggered when `/define` detects an existing `prd.md` AND the u
 After PRD revision is approved, surface downstream impacts. Do NOT automatically reset any downstream artifacts -- the user decides what needs re-review.
 
 7. **List affected downstream artifacts** that MAY need re-review:
-   - `docs/ARCHITECTURE_AND_DESIGN.md` (if exists) -- design may be invalidated by scope changes
-   - `milestones/*/README.md` (if any exist) -- milestone breakdown may need updating
-   - `milestones/*/plans/*.md` (if any exist) -- implementation plans may be affected
+   - `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` (if exists) -- design may be invalidated by scope changes
+   - `.project/{slug}/milestones/*/README.md` (if any exist) -- milestone breakdown may need updating
+   - `.project/{slug}/milestones/*/plans/*.md` (if any exist) -- implementation plans may be affected
 8. **Present this list to the user** and ask which (if any) need re-review
 9. **Do NOT automatically reset** any downstream artifact status -- no automatic cascade (DD-6)
 10. **Record Gate 1 re-approval** in `progress.txt` with updated date: `[x] Gate 1: Scope Review  Approved: <YYYY-MM-DD>  prd.md`

--- a/skills/project/define/references/gate-wb-working-backwards.md
+++ b/skills/project/define/references/gate-wb-working-backwards.md
@@ -2,6 +2,8 @@
 
 An optional gate that produces a customer-outcome narrative before PRD creation. Working Backwards starts with the customer experience and works backward to the technical solution. This reference contains the complete Gate WB specification -- an executor reading only this file can run the full Gate WB flow.
 
+`{slug}` is read from the `# Project-ID: <slug>` header in `progress.txt` at session start. All artifact paths in this document use `.project/{slug}/` as the base path.
+
 ## Gate WB Offer (DEF-08)
 
 After Gate 0 is complete (or skipped for greenfield), offer Gate WB to the user.
@@ -67,10 +69,10 @@ Ask the user:
 
 ## Document Production (DEF-09)
 
-Produce `docs/working-backwards.md` from the interview answers:
+Produce `.project/{slug}/docs/working-backwards.md` from the interview answers:
 
-1. Create `docs/` directory if it does not exist: `mkdir -p docs`
-2. Write `docs/working-backwards.md` with these required sections:
+1. Create `.project/{slug}/docs/` directory if it does not exist: `mkdir -p .project/{slug}/docs`
+2. Write `.project/{slug}/docs/working-backwards.md` with these required sections:
 
 ### Press Release
 
@@ -119,7 +121,7 @@ Present the Working Backwards document to the user using the produce-then-review
    - **Approve** -- document captures the right customer outcome, proceed to checklist validation
    - **Revise** -- document needs corrections
 
-3. **If Revise:** Ask the user what needs changing. Apply edits to `docs/working-backwards.md`. Re-present the updated document. Repeat until the user selects Approve.
+3. **If Revise:** Ask the user what needs changing. Apply edits to `.project/{slug}/docs/working-backwards.md`. Re-present the updated document. Repeat until the user selects Approve.
 
 4. **If Approve:** Proceed to Checklist Validation.
 
@@ -127,14 +129,14 @@ Present the Working Backwards document to the user using the produce-then-review
 
 Generate and validate the review checklist:
 
-1. Create `docs/reviews/` directory if needed: `mkdir -p docs/reviews`
+1. Create `.project/{slug}/docs/reviews/` directory if needed: `mkdir -p .project/{slug}/docs/reviews`
 
-2. Generate `docs/reviews/gate-wb-review.md` using the Gate WB section from `references/review-checklist-template.md`. Start with the file header:
+2. Generate `.project/{slug}/docs/reviews/gate-wb-review.md` using the Gate WB section from `references/review-checklist-template.md`. Start with the file header:
 
    ```
    # Gate WB Review -- Working Backwards
 
-   **Artifact:** docs/working-backwards.md
+   **Artifact:** .project/{slug}/docs/working-backwards.md
    **Status:** [ ] Pending
    **Reviewer(s):**
    **Date:**
@@ -153,7 +155,7 @@ Generate and validate the review checklist:
    - `[ ] [Auto] Confirm scope alignment: "{specific feature mentioned}"`
 
 5. **Claude pre-checks** items it can verify programmatically:
-   - File `docs/working-backwards.md` exists
+   - File `.project/{slug}/docs/working-backwards.md` exists
    - All required sections are present (Press Release, External FAQ, Internal FAQ)
    - Press release contains all required elements (headline, subheading, etc.)
 
@@ -175,7 +177,7 @@ Record the gate approval in progress.txt:
    ```
    to:
    ```
-   [x] Gate WB: Working Backwards  Approved: <YYYY-MM-DD>  docs/working-backwards.md
+   [x] Gate WB: Working Backwards  Approved: <YYYY-MM-DD>  .project/{slug}/docs/working-backwards.md
    ```
    where `<YYYY-MM-DD>` is the current date.
 

--- a/skills/project/define/references/progress-format.md
+++ b/skills/project/define/references/progress-format.md
@@ -22,6 +22,7 @@ The exact `progress.txt` content created by `/project` on first run (the only ti
 ```
 # Progress: <Project Name>
 # Created: <ISO date>
+# Project-ID: <slug>
 # Status: [ ] pending  [~] in progress  [x] complete  [-] skipped
 
 ## Gates
@@ -44,8 +45,13 @@ The exact `progress.txt` content created by `/project` on first run (the only ti
 Notes:
 
 - `<Project Name>` is derived from the project directory name or user input at bootstrap time.
+- `<slug>` is the slugified form of the project name (lowercase, hyphens, alphanumeric only).
 - `<ISO date>` is the current date in YYYY-MM-DD format.
 - The `# Status:` header line serves as an inline legend for anyone reading the file.
+
+Parsing instruction for skills: find the line starting with `# Project-ID:`, take the
+value after `:`, trim whitespace, and use it as `<slug>`. Construct the artifact base
+path as `.project/<slug>/`.
 
 ## Greenfield Bootstrap Variant
 
@@ -64,10 +70,13 @@ Gate entries appear in the `## Gates` section, one per line. The format varies b
 **Approved:**
 
 ```
-[x] Gate 0: Codebase Alignment  Approved: 2026-03-15  docs/codebase-assessment.md
+[x] Gate 0: Codebase Alignment  Approved: 2026-03-15  .project/<slug>/docs/codebase-assessment.md
 ```
 
 Format: `[x] Gate N: Name  Approved: <YYYY-MM-DD>  <artifact-path>`
+
+The artifact path is relative to the project root and uses the `.project/<slug>/` base
+path derived from the `# Project-ID: <slug>` header in `progress.txt`.
 
 **Skipped:**
 

--- a/skills/project/design/SKILL.md
+++ b/skills/project/design/SKILL.md
@@ -12,8 +12,8 @@ disable-model-invocation: true
 
 # /design -- Architecture and Design (Gate 2)
 
-Produces `docs/ARCHITECTURE_AND_DESIGN.md` from an approved PRD and optional
-codebase assessment, with in-session revision before gate approval. Supports
+Produces `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` from an approved PRD and
+optional codebase assessment, with in-session revision before gate approval. Supports
 refresh mode to consolidate accumulated architectural deviations from feature
 plans.
 
@@ -41,7 +41,9 @@ plans.
 
 ## Step 1 -- Detect Mode and State
 
-Read `progress.txt` from the project root.
+Read `progress.txt` from the project root. Parse `# Project-ID: <slug>` from the
+header and construct the artifact base path: `.project/<slug>/`. Use this base path
+for all artifact reads and writes throughout this session.
 
 **Prerequisite check (DES-01):**
 If Gate 1 is not `[x]` approved in `progress.txt`, inform the user:
@@ -52,12 +54,12 @@ Do not proceed. End the session.
 **Refresh mode detection (DES-08):**
 Check ALL of the following:
 - Gate 2 is `[x]` approved in `progress.txt`
-- `docs/ARCHITECTURE_AND_DESIGN.md` exists on disk
+- `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` exists on disk
 
 If ALL true: jump to Step 4 (Refresh Mode).
 
 **Already-approved detection (no refresh intent):**
-If Gate 2 is `[x]` approved AND `docs/ARCHITECTURE_AND_DESIGN.md` exists AND
+If Gate 2 is `[x]` approved AND `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` exists AND
 the user's message does NOT signal refresh intent (keywords: "refresh", "update
 architecture", "consolidate deviations", "sync deviations"):
 Inform the user Gate 2 is already approved. Use `AskUserQuestion` with options:
@@ -65,7 +67,7 @@ Inform the user Gate 2 is already approved. Use `AskUserQuestion` with options:
 
 **Normal mode:**
 If Gate 2 is not yet approved: proceed to Step 2 (Architecture Generation).
-Before generating, Step 2 checks whether `docs/ARCHITECTURE_AND_DESIGN.md`
+Before generating, Step 2 checks whether `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md`
 already exists on disk and integrates into it rather than overwriting (see
 references/gate-2-design.md for details).
 
@@ -74,14 +76,14 @@ references/gate-2-design.md for details).
 Read `references/gate-2-design.md` for the complete Gate 2 specification.
 
 Follow the gate-2-design specification to:
-1. Read `prd.md` and `docs/codebase-assessment.md` (if exists) (DES-02).
+1. Read `prd.md` and `.project/{slug}/docs/codebase-assessment.md` (if exists) (DES-02).
 2. Spawn architecture sub-agent to scan 15-30 files (D-05, D-06).
-3. Synthesize findings + PRD into `docs/ARCHITECTURE_AND_DESIGN.md` using
+3. Synthesize findings + PRD into `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` using
    `assets/architecture-template.md` (DES-03).
 4. Present tradeoff callouts for 2-4 key decisions (D-09).
 5. Enter produce-then-review cycle with section-by-section partial approval
    (DES-05, DES-06, D-08).
-6. Generate and validate review checklist `docs/reviews/gate-2-review.md`
+6. Generate and validate review checklist `.project/{slug}/docs/reviews/gate-2-review.md`
    (DES-04, D-11).
 7. Record Gate 2 approval in `progress.txt` (DES-07).
 
@@ -95,10 +97,10 @@ Display summary of what was produced:
 DESIGN COMPLETE: [Project Title]
 
 ARTIFACTS CREATED:
-- docs/ARCHITECTURE_AND_DESIGN.md (Gate 2)
+- .project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md (Gate 2)
 
 REVIEW CHECKLISTS:
-- docs/reviews/gate-2-review.md
+- .project/{slug}/docs/reviews/gate-2-review.md
 
 NEXT: Run /project to see updated status, then /milestone for Gate 3.
 ```
@@ -108,12 +110,12 @@ NEXT: Run /project to see updated status, then /milestone for Gate 3.
 Read `references/refresh-mode.md` for the complete refresh mode specification.
 
 Follow the refresh-mode specification to:
-1. Scan `milestones/*/plans/*.md` for Architectural Deviations sections.
+1. Scan `.project/{slug}/milestones/*/plans/*.md` for Architectural Deviations sections.
 2. If zero deviations found: report "No architectural deviations found.
    Architecture doc is current." and exit (D-14).
 3. Present each deviation with original design decision context (D-12).
 4. User selects which deviations to consolidate via multiSelect.
-5. Apply selected deviations to `docs/ARCHITECTURE_AND_DESIGN.md` (D-13).
+5. Apply selected deviations to `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` (D-13).
 6. Present updated doc for section-by-section review.
 7. Update Gate 2 date in `progress.txt`.
 
@@ -124,7 +126,7 @@ DESIGN REFRESHED: [Project Title]
 
 DEVIATIONS CONSOLIDATED: N of M
 ARTIFACTS UPDATED:
-- docs/ARCHITECTURE_AND_DESIGN.md (refreshed)
+- .project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md (refreshed)
 
 NEXT: Run /project to see updated status.
 ```

--- a/skills/project/design/references/gate-2-design.md
+++ b/skills/project/design/references/gate-2-design.md
@@ -1,13 +1,15 @@
 # Gate 2: Design Review
 
-Produces `docs/ARCHITECTURE_AND_DESIGN.md` from an approved PRD and optional codebase assessment. This reference contains the complete Gate 2 specification -- an executor reading only this file can run the full Gate 2 normal-mode flow.
+Produces `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` from an approved PRD and optional codebase assessment. This reference contains the complete Gate 2 specification -- an executor reading only this file can run the full Gate 2 normal-mode flow.
+
+`{slug}` is read from the `# Project-ID: <slug>` header in `progress.txt` at session start. All artifact paths in this document use `.project/{slug}/` as the base path.
 
 ## Input Loading (DES-02, D-07)
 
 Read the primary inputs from disk:
 
 1. **Read `prd.md`** from the project root. This is required -- if it does not exist, report the error and stop.
-2. **Read `docs/codebase-assessment.md`** if it exists. This is optional -- it may not exist for greenfield projects. If missing, proceed without it.
+2. **Read `.project/{slug}/docs/codebase-assessment.md`** if it exists. This is optional -- it may not exist for greenfield projects. If missing, proceed without it.
 
 Both files are primary inputs per D-07. The PRD provides goals, non-goals, scope, risks, and milestone intent. The codebase assessment (when present) provides existing patterns, architecture, and constraints.
 
@@ -59,16 +61,16 @@ The synthesis step compensates by drawing architecture decisions primarily from 
 
 ## Architecture Document Production (DES-03, D-04)
 
-Synthesize the agent's findings and the PRD into `docs/ARCHITECTURE_AND_DESIGN.md`:
+Synthesize the agent's findings and the PRD into `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md`:
 
 1. Read the agent's scratch file (`/tmp/architecture-scan-findings.md`)
 2. Read `assets/architecture-template.md` for the document structure
-3. Create the `docs/` directory if it does not exist: `mkdir -p docs`
-4. **Check whether `docs/ARCHITECTURE_AND_DESIGN.md` already exists on disk.**
+3. Create the `.project/{slug}/docs/` directory if it does not exist: `mkdir -p .project/{slug}/docs`
+4. **Check whether `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` already exists on disk.**
 
 ### If the file does NOT exist (new document)
 
-Write `docs/ARCHITECTURE_AND_DESIGN.md` from scratch using the template, populating each of the 6 required sections listed below.
+Write `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` from scratch using the template, populating each of the 6 required sections listed below.
 
 ### If the file DOES exist (integrate into existing)
 
@@ -140,7 +142,7 @@ Present the architecture document for user review using the produce-then-review 
 
    The user checks the sections they approve. For each unchecked section, ask: "What should change in [Section Name]?" Apply the requested changes using the Edit tool. Re-present the updated sections for confirmation. Repeat until all sections are approved or the user does a full Approve.
 
-6. **If Revise:** Ask what needs changing. Apply edits to `docs/ARCHITECTURE_AND_DESIGN.md`. Re-present the updated summary. Repeat until the user selects Approve.
+6. **If Revise:** Ask what needs changing. Apply edits to `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md`. Re-present the updated summary. Repeat until the user selects Approve.
 
 7. **If Approve:** Proceed to Checklist Validation.
 
@@ -148,14 +150,14 @@ Present the architecture document for user review using the produce-then-review 
 
 Generate and validate the review checklist:
 
-1. Create `docs/reviews/` directory if needed: `mkdir -p docs/reviews`
+1. Create `.project/{slug}/docs/reviews/` directory if needed: `mkdir -p .project/{slug}/docs/reviews`
 
-2. Generate `docs/reviews/gate-2-review.md` using `references/review-checklist-template.md`. Start with the file header:
+2. Generate `.project/{slug}/docs/reviews/gate-2-review.md` using `references/review-checklist-template.md`. Start with the file header:
 
    ```
    # Gate 2 Review -- Design Review
 
-   **Artifact:** docs/ARCHITECTURE_AND_DESIGN.md
+   **Artifact:** .project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md
    **Status:** [ ] Pending
    **Reviewer(s):**
    **Date:**
@@ -174,7 +176,7 @@ Generate and validate the review checklist:
    - `[ ] [Auto] Validate security: "{specific security measure}" is sufficient`
 
 5. **Claude pre-checks** items it can verify programmatically:
-   - File `docs/ARCHITECTURE_AND_DESIGN.md` exists
+   - File `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` exists
    - All 6 required sections are present
    - Design Decisions table has at least one entry
    - Component Inventory table has at least one entry
@@ -197,7 +199,7 @@ Record the gate approval in progress.txt:
    ```
    to:
    ```
-   [x] Gate 2: Design Review  Approved: <YYYY-MM-DD>  docs/ARCHITECTURE_AND_DESIGN.md
+   [x] Gate 2: Design Review  Approved: <YYYY-MM-DD>  .project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md
    ```
    where `<YYYY-MM-DD>` is the current date.
 

--- a/skills/project/design/references/progress-format.md
+++ b/skills/project/design/references/progress-format.md
@@ -22,6 +22,7 @@ The exact `progress.txt` content created by `/project` on first run (the only ti
 ```
 # Progress: <Project Name>
 # Created: <ISO date>
+# Project-ID: <slug>
 # Status: [ ] pending  [~] in progress  [x] complete  [-] skipped
 
 ## Gates
@@ -44,8 +45,13 @@ The exact `progress.txt` content created by `/project` on first run (the only ti
 Notes:
 
 - `<Project Name>` is derived from the project directory name or user input at bootstrap time.
+- `<slug>` is the slugified form of the project name (lowercase, hyphens, alphanumeric only).
 - `<ISO date>` is the current date in YYYY-MM-DD format.
 - The `# Status:` header line serves as an inline legend for anyone reading the file.
+
+Parsing instruction for skills: find the line starting with `# Project-ID:`, take the
+value after `:`, trim whitespace, and use it as `<slug>`. Construct the artifact base
+path as `.project/<slug>/`.
 
 ## Greenfield Bootstrap Variant
 
@@ -64,10 +70,13 @@ Gate entries appear in the `## Gates` section, one per line. The format varies b
 **Approved:**
 
 ```
-[x] Gate 0: Codebase Alignment  Approved: 2026-03-15  docs/codebase-assessment.md
+[x] Gate 0: Codebase Alignment  Approved: 2026-03-15  .project/<slug>/docs/codebase-assessment.md
 ```
 
 Format: `[x] Gate N: Name  Approved: <YYYY-MM-DD>  <artifact-path>`
+
+The artifact path is relative to the project root and uses the `.project/<slug>/` base
+path derived from the `# Project-ID: <slug>` header in `progress.txt`.
 
 **Skipped:**
 

--- a/skills/project/design/references/refresh-mode.md
+++ b/skills/project/design/references/refresh-mode.md
@@ -1,13 +1,15 @@
 # Refresh Mode: Architectural Deviation Consolidation
 
-Consolidates accumulated architectural deviations from feature plans back into `docs/ARCHITECTURE_AND_DESIGN.md`. This reference contains the complete refresh mode specification -- an executor reading only this file can run the full refresh flow.
+Consolidates accumulated architectural deviations from feature plans back into `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md`. This reference contains the complete refresh mode specification -- an executor reading only this file can run the full refresh flow.
+
+`{slug}` is read from the `# Project-ID: <slug>` header in `progress.txt` at session start. All artifact paths in this document use `.project/{slug}/` as the base path.
 
 ## Entry Condition
 
 Refresh mode is entered when ALL of the following are true:
 
 1. Gate 2 is `[x]` approved in `progress.txt`
-2. `docs/ARCHITECTURE_AND_DESIGN.md` exists on disk
+2. `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` exists on disk
 
 SKILL.md detects this in Step 1 and jumps to the refresh step. If either condition is false, this is not refresh mode -- use gate-2-design.md for normal mode instead.
 
@@ -15,10 +17,10 @@ SKILL.md detects this in Step 1 and jumps to the refresh step. If either conditi
 
 Scan all feature plan files for architectural deviations:
 
-1. Use `Glob` to find all files matching `milestones/*/plans/*.md`.
+1. Use `Glob` to find all files matching `.project/{slug}/milestones/*/plans/*.md`.
 2. Read each file and search for the `## Architectural Deviations` heading.
 3. Extract non-empty deviation entries. A section exists but contains only placeholder text (e.g., "Empty if the feature was built as designed") counts as empty -- skip it.
-4. For each non-empty deviation, also identify the original design decision it modifies by matching the decision number or description against the Design Decisions table in `docs/ARCHITECTURE_AND_DESIGN.md`.
+4. For each non-empty deviation, also identify the original design decision it modifies by matching the decision number or description against the Design Decisions table in `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md`.
 
 Collect all deviations with their source file, deviation description, and the original design decision they affect.
 
@@ -35,7 +37,7 @@ This is the expected outcome when implementation matched the original design.
 
 Present each deviation to the user individually, showing:
 
-1. **Original design decision** from `docs/ARCHITECTURE_AND_DESIGN.md` -- the decision number, the decision text, and the rationale
+1. **Original design decision** from `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md` -- the decision number, the decision text, and the rationale
 2. **Deviation description** from the feature plan -- what changed and why
 3. **Reason for the change** -- the circumstances that forced the deviation (failed approach, new constraint, technology change)
 
@@ -49,7 +51,7 @@ The user checks the deviations they want consolidated. Unchecked deviations are 
 
 ## Consolidation
 
-Apply selected deviations to `docs/ARCHITECTURE_AND_DESIGN.md`:
+Apply selected deviations to `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md`:
 
 1. **Design Decisions table:** Update the affected decision rows with revised decision text, rationale, and tradeoff. If a deviation introduces an entirely new decision, add a new numbered row.
 2. **Component Inventory:** Update if the deviation added, removed, or changed components.
@@ -64,7 +66,7 @@ Use the Edit tool for all updates to preserve the rest of the document.
 
 After consolidation, present the updated architecture document for approval using the same section-by-section review flow as normal mode:
 
-1. Present a summary of the changes made to the architecture document
+1. Present a summary of the changes made to `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md`
 2. Use `AskUserQuestion` with options: **Approve** / **Revise** / **Partial**
 3. If **Partial:** multiSelect checklist of the 6 architecture sections. User checks approved sections. Unchecked sections get focused revision with "What should change in [Section Name]?" prompt. Re-present after revision.
 4. If **Revise:** Ask what needs changing, apply edits, re-present.
@@ -77,7 +79,7 @@ Update the Gate 2 date in `progress.txt` to reflect the refresh:
 1. Read `references/progress-format.md` for the exact gate entry format.
 2. Update the Gate 2 line in `progress.txt` to:
    ```
-   [x] Gate 2: Design Review  Approved: <YYYY-MM-DD>  docs/ARCHITECTURE_AND_DESIGN.md
+   [x] Gate 2: Design Review  Approved: <YYYY-MM-DD>  .project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md
    ```
    where `<YYYY-MM-DD>` is the current date (reflecting the refresh date, not the original approval date).
 3. Only `progress.txt` is updated -- no other state files are modified.

--- a/skills/project/milestone/SKILL.md
+++ b/skills/project/milestone/SKILL.md
@@ -44,7 +44,10 @@ handled by `/project`.
 
 ## Step 1 -- Detect Mode and State
 
-Read `progress.txt` from the project root.
+Read `progress.txt` from the project root. Parse `# Project-ID: <slug>` from the
+header and construct the artifact base path: `.project/<slug>/`. If the header is
+missing, report the error and tell the user to run `/project` first to bootstrap
+a Project-ID.
 
 **Prerequisite check (MIL-01):**
 If Gate 2 is not `[x]` approved in `progress.txt`, inform the user:
@@ -57,16 +60,17 @@ Read the `prd.md` Milestones section.
 **Mode detection -- 4 branches:**
 
 1. **First invocation:** `prd.md` Milestones section is `(to be defined)` AND no
-   `milestones/` directories exist --> proceed to Step 2.
+   `.project/<slug>/milestones/` directories exist --> proceed to Step 2.
 2. **Subsequent invocation:** `prd.md` Milestones section is populated AND some
-   milestones lack directories --> proceed to Step 3.
-3. **Revision mode:** Target milestone directory already exists (D-10) -->
-   proceed to Step 5. If the user specified a milestone number or name, use that.
-   Otherwise use `AskUserQuestion` to ask which milestone to revise.
+   milestones lack directories under `.project/<slug>/milestones/` --> proceed to Step 3.
+3. **Revision mode:** Target milestone directory already exists under
+   `.project/<slug>/milestones/` (D-10) --> proceed to Step 5. If the user specified
+   a milestone number or name, use that. Otherwise use `AskUserQuestion` to ask
+   which milestone to revise.
 4. **All milestones defined:** `prd.md` Milestones section is populated AND all
-   milestones have directories --> inform the user all milestones are defined.
-   Suggest running `/project` to check gate status or specify a milestone number
-   for revision.
+   milestones have directories under `.project/<slug>/milestones/` --> inform the
+   user all milestones are defined. Suggest running `/project` to check gate status
+   or specify a milestone number for revision.
 
 ## Step 2 -- First Invocation: Propose Milestone Plan
 
@@ -74,7 +78,7 @@ Read `references/gate-3-milestone.md` for the complete Gate 3 specification.
 
 Follow the "First Invocation" section of the gate-3-milestone specification to:
 
-1. Read `prd.md` and `docs/ARCHITECTURE_AND_DESIGN.md` (MIL-02).
+1. Read `prd.md` and `.project/<slug>/docs/ARCHITECTURE_AND_DESIGN.md` (MIL-02).
 2. Propose full milestone plan with summaries and ordering (D-07, D-01).
 3. Present tradeoff callouts (D-03).
 4. Approve/Revise cycle.
@@ -129,9 +133,9 @@ Display summary:
 MILESTONE DEFINED: [Milestone NN: Name]  (or MILESTONE REVISED)
 
 ARTIFACTS CREATED:  (or ARTIFACTS UPDATED)
-- milestones/<NN>-<name>/README.md
-- milestones/<NN>-<name>/milestone-status.txt
-- milestones/<NN>-<name>/reviews/gate-3-review.md
+- .project/<slug>/milestones/<NN>-<name>/README.md
+- .project/<slug>/milestones/<NN>-<name>/milestone-status.txt
+- .project/<slug>/milestones/<NN>-<name>/reviews/gate-3-review.md
 
 STATE UPDATED:
 - progress.txt (Gate 3: [~] In progress, milestone summary line)

--- a/skills/project/milestone/references/gate-3-milestone.md
+++ b/skills/project/milestone/references/gate-3-milestone.md
@@ -2,30 +2,32 @@
 
 Produces milestone-scoped feature breakdowns from an approved PRD and architecture document. This reference contains the complete Gate 3 specification for normal mode (first invocation and subsequent invocations) -- an executor reading only this file can run the full Gate 3 flow.
 
+`{slug}` is read from the `# Project-ID: <slug>` header in `progress.txt` at session start. All artifact paths in this document use `.project/{slug}/` as the base path.
+
 ## Input Loading (MIL-02, D-02, D-04)
 
 Read the primary inputs from disk:
 
 1. **Read `prd.md`** from the project root. This is required -- if it does not exist, report the error and stop.
-2. **Read `docs/ARCHITECTURE_AND_DESIGN.md`** from the project root. This is required -- if it does not exist, report the error and stop.
+2. **Read `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md`** from the project root. This is required -- if it does not exist, report the error and stop.
 3. **Read `progress.txt`** from the project root. This is required -- if it does not exist, report the error and stop.
 
 All three files are primary inputs per D-02. The PRD provides goals, non-goals, scope, risk assessment, and milestone intent. The architecture document provides component inventory, data flow, design decisions, and technical constraints. The progress file provides current gate status.
 
-**Spike artifacts (D-04):** Do not auto-detect or auto-scan `docs/spikes/`. If the user explicitly references a spike during the session (e.g., "see the websocket auth spike"), read `docs/spikes/<topic>.md` on request. Spike artifacts are user-referenced only.
+**Spike artifacts (D-04):** Do not auto-detect or auto-scan `.project/{slug}/docs/spikes/`. If the user explicitly references a spike during the session (e.g., "see the websocket auth spike"), read `.project/{slug}/docs/spikes/<topic>.md` on request. Spike artifacts are user-referenced only.
 
 ## Mode Detection
 
 After loading inputs, determine which mode to enter:
 
-1. **First invocation:** `prd.md` Milestones section contains `(to be defined)` AND no `milestones/` directories exist on disk. Proceed to Section 4 (Propose Milestone Plan).
-2. **Subsequent invocation:** `prd.md` Milestones section is populated with an approved milestone plan AND at least one milestone still lacks a directory under `milestones/`. Proceed to Section 5 (Auto-Select Next Milestone).
-3. **Revision mode:** The target milestone directory already exists under `milestones/`. This is handled by `references/revision-mode.md`, not this file. SKILL.md routes to revision mode directly.
+1. **First invocation:** `prd.md` Milestones section contains `(to be defined)` AND no `.project/{slug}/milestones/` directories exist on disk. Proceed to Section 4 (Propose Milestone Plan).
+2. **Subsequent invocation:** `prd.md` Milestones section is populated with an approved milestone plan AND at least one milestone still lacks a directory under `.project/{slug}/milestones/`. Proceed to Section 5 (Auto-Select Next Milestone).
+3. **Revision mode:** The target milestone directory already exists under `.project/{slug}/milestones/`. This is handled by `references/revision-mode.md`, not this file. SKILL.md routes to revision mode directly.
 
 Detection logic:
 
 - Check `prd.md` Milestones section content (is it `(to be defined)` or populated?)
-- Run `ls milestones/` to see which milestone directories exist
+- Run `ls .project/{slug}/milestones/` to see which milestone directories exist
 - Compare the milestone plan in `prd.md` against existing directories to identify the next undefined milestone
 
 ## First Invocation: Propose Milestone Plan (D-07, D-01)
@@ -91,7 +93,7 @@ After persisting the milestone plan in `prd.md`:
 On subsequent invocations (milestone plan exists in `prd.md` but not all milestones have directories):
 
 1. Read `prd.md` Milestones section for the approved milestone plan
-2. Run `ls milestones/` to identify which milestones already have directories
+2. Run `ls .project/{slug}/milestones/` to identify which milestones already have directories
 3. Auto-select the next milestone in sequence that lacks a directory
 4. Report the selection: "Next undefined milestone: Milestone NN: Name"
 
@@ -105,21 +107,21 @@ Generate the complete set of artifacts for a single milestone.
 
 ### Sequence Number (MIL-03)
 
-Auto-increment the sequence number from existing `milestones/` directories:
+Auto-increment the sequence number from existing `.project/{slug}/milestones/` directories:
 
-- Run `ls milestones/` to count existing milestone directories
+- Run `ls .project/{slug}/milestones/` to count existing milestone directories
 - Use the milestone's position in the approved plan (from `prd.md`) for the sequence number
 - Zero-pad to two digits (e.g., `01`, `02`, `03`)
 
 ### Directory Creation
 
 ```bash
-mkdir -p milestones/<NN>-<kebab-name>/reviews/
+mkdir -p .project/{slug}/milestones/<NN>-<kebab-name>/reviews/
 ```
 
 ### README.md Generation (MIL-04)
 
-Read `assets/milestone-readme-template.md` for the template structure. Generate `milestones/<NN>-<name>/README.md` with all required sections populated:
+Read `assets/milestone-readme-template.md` for the template structure. Generate `.project/{slug}/milestones/<NN>-<name>/README.md` with all required sections populated:
 
 - **Goal** -- 1-3 sentences describing customer-visible outcome (not internal refactoring)
 - **Features** -- 2-5 features per milestone (DD-1), each with specific, testable acceptance criteria
@@ -131,7 +133,7 @@ Read `assets/milestone-readme-template.md` for the template structure. Generate 
 
 ### milestone-status.txt Generation (MIL-05)
 
-Generate `milestones/<NN>-<name>/milestone-status.txt` with all features at `[ ]` pending status. Follow the format from `references/progress-format.md`:
+Generate `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt` with all features at `[ ]` pending status. Follow the format from `references/progress-format.md`:
 
 ```
 # Milestone NN: Name
@@ -148,7 +150,7 @@ Generate `milestones/<NN>-<name>/milestone-status.txt` with all features at `[ ]
 
 ### gate-3-review.md Generation (MIL-06)
 
-Generate `milestones/<NN>-<name>/reviews/gate-3-review.md` using the format from `references/review-checklist-template.md`. This checklist is per-milestone (not at `docs/reviews/` like Gates 0-2).
+Generate `.project/{slug}/milestones/<NN>-<name>/reviews/gate-3-review.md` using the format from `references/review-checklist-template.md`. This checklist is per-milestone (not at `.project/{slug}/docs/reviews/` like Gates 0-2).
 
 ### progress.txt Updates (MIL-07, MIL-09)
 
@@ -167,7 +169,7 @@ After writing `milestone-status.txt`, update `progress.txt`:
 2. **Milestone summary line (MIL-07):** Add a new line in the `## Milestones` section:
 
    ```
-   [ ] Milestone NN: Name  milestones/<NN>-<name>/  0/N features complete
+   [ ] Milestone NN: Name  .project/{slug}/milestones/<NN>-<name>/  0/N features complete
    ```
 
    Follow the Milestone Summary Line Format from `references/progress-format.md`.
@@ -207,12 +209,12 @@ Generate and validate the review checklist for this milestone.
 
 1. Read `references/review-checklist-template.md` for the Gate 3 template structure.
 
-2. The checklist was generated during Section 6 at `milestones/<NN>-<name>/reviews/gate-3-review.md`. Read it now.
+2. The checklist was generated during Section 6 at `.project/{slug}/milestones/<NN>-<name>/reviews/gate-3-review.md`. Read it now.
 
 3. **Claude pre-checks** items that can be verified programmatically:
-   - `milestones/<NN>-<name>/README.md` exists
+   - `.project/{slug}/milestones/<NN>-<name>/README.md` exists
    - All required sections present in README.md (Goal, Features, Dependencies, Ordering, Sizing, Definition of Done)
-   - `milestones/<NN>-<name>/milestone-status.txt` exists
+   - `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt` exists
    - Feature count in `milestone-status.txt` matches feature count in README.md
    - Each feature has at least one acceptance criterion
 

--- a/skills/project/milestone/references/progress-format.md
+++ b/skills/project/milestone/references/progress-format.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The project pipeline uses plain-text checkbox notation across two tiers of state files: a project-level `progress.txt` at the project root (tracking gate approvals, milestone summaries, and spike entries) and milestone-level `milestone-status.txt` files at `milestones/<NN>-<name>/milestone-status.txt` (tracking per-feature details, sub-feature checklists, and notes). Both files use the same four-marker status notation defined below. This format was chosen over YAML for superior write-safety, token efficiency (~53% fewer tokens), and human editability (see DESIGN.md DD-3, progress-file/TEXT_vs_YAML_REPORT.md).
+The project pipeline uses plain-text checkbox notation across two tiers of state files: a project-level `progress.txt` at the project root (tracking gate approvals, milestone summaries, and spike entries) and milestone-level `milestone-status.txt` files at `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt` (tracking per-feature details, sub-feature checklists, and notes). Both files use the same four-marker status notation defined below. This format was chosen over YAML for superior write-safety, token efficiency (~53% fewer tokens), and human editability (see DESIGN.md DD-3, progress-file/TEXT_vs_YAML_REPORT.md).
 
 ## Status Notation
 
@@ -106,10 +106,10 @@ The artifact path on approved entries is the primary deliverable of that gate. `
 One line per milestone in the `## Milestones` section:
 
 ```
-[ ] Milestone 01: Core Auth  milestones/01-core-auth/  0/3 features complete
+[ ] Milestone 01: Core Auth  .project/{slug}/milestones/01-core-auth/  0/3 features complete
 ```
 
-Format: `[status] Milestone NN: Name  milestones/<NN>-<name>/  N/M features complete`
+Format: `[status] Milestone NN: Name  .project/{slug}/milestones/<NN>-<name>/  N/M features complete`
 
 Where:
 
@@ -138,7 +138,7 @@ Format: `[status] Spike Name  <artifact-path>` with an optional `Resolved: <date
 
 ## milestone-status.txt Format
 
-Per-milestone file located at `milestones/<NN>-<name>/milestone-status.txt`. Uses the same checkbox notation as `progress.txt` (per STATE-02). Contains detailed feature tracking for a single milestone.
+Per-milestone file located at `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt`. Uses the same checkbox notation as `progress.txt` (per STATE-02). Contains detailed feature tracking for a single milestone.
 
 ```
 # Milestone 01: Core Auth
@@ -147,11 +147,11 @@ Per-milestone file located at `milestones/<NN>-<name>/milestone-status.txt`. Use
 ## Features
 
 [x] Feature 01.1: User Registration
-    Plan: milestones/01-core-auth/plans/user-registration.md
+    Plan: .project/{slug}/milestones/01-core-auth/plans/user-registration.md
     Sub-features: 3/3 complete
 
 [~] Feature 01.2: Session Management
-    Plan: milestones/01-core-auth/plans/session-management.md
+    Plan: .project/{slug}/milestones/01-core-auth/plans/session-management.md
     Sub-features: 1/4 complete
     Notes: Switched from JWT to session cookies (see architectural deviation)
 

--- a/skills/project/milestone/references/revision-mode.md
+++ b/skills/project/milestone/references/revision-mode.md
@@ -4,7 +4,7 @@ Handles scope changes to an existing milestone by selectively resetting affected
 
 ## Entry Condition (D-10)
 
-Revision mode is entered when the target milestone directory already exists on disk. SKILL.md auto-detects this in Step 1 by checking whether `milestones/<NN>-<name>/` is present.
+Revision mode is entered when the target milestone directory already exists on disk. SKILL.md auto-detects this in Step 1 by checking whether `.project/{slug}/milestones/<NN>-<name>/` is present.
 
 If the target milestone directory does not exist, this is not revision mode -- use `references/gate-3-milestone.md` for normal mode (first invocation or subsequent invocation).
 
@@ -12,8 +12,8 @@ If the target milestone directory does not exist, this is not revision mode -- u
 
 Read the existing milestone artifacts from disk:
 
-1. **Read `milestones/<NN>-<name>/README.md`** -- the existing milestone definition with goal, features, dependencies, ordering, sizing, and definition of done.
-2. **Read `milestones/<NN>-<name>/milestone-status.txt`** -- the current feature statuses showing which features are complete, in progress, or pending.
+1. **Read `.project/{slug}/milestones/<NN>-<name>/README.md`** -- the existing milestone definition with goal, features, dependencies, ordering, sizing, and definition of done.
+2. **Read `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt`** -- the current feature statuses showing which features are complete, in progress, or pending.
 
 Both files are required. If either is missing, report the error and stop.
 
@@ -44,7 +44,7 @@ After identifying affected features, perform a focused revision of the milestone
 
 1. **Ask "What changed?"** -- understand the nature of the scope change (new requirements, removed features, modified acceptance criteria, dependency changes, etc.)
 
-2. **Load existing `milestones/<NN>-<name>/README.md`** content (already read in the Load step above).
+2. **Load existing `.project/{slug}/milestones/<NN>-<name>/README.md`** content (already read in the Load step above).
 
 3. **Revise only affected sections** -- do NOT discard and regenerate the entire README. Use the Edit tool to apply targeted changes:
    - If features were added: add new feature subsections with acceptance criteria
@@ -63,11 +63,11 @@ After revising the README, update all related artifacts. Follow write-ordering (
 
 ### 1. Generate Fresh gate-3-review.md (D-13)
 
-Generate a fresh `milestones/<NN>-<name>/reviews/gate-3-review.md` checklist using `references/review-checklist-template.md`. The prior review is no longer valid after a scope change -- a new review must be conducted against the revised milestone definition.
+Generate a fresh `.project/{slug}/milestones/<NN>-<name>/reviews/gate-3-review.md` checklist using `references/review-checklist-template.md`. The prior review is no longer valid after a scope change -- a new review must be conducted against the revised milestone definition.
 
 ### 2. Update milestone-status.txt (Write First -- STATE-04)
 
-Update `milestones/<NN>-<name>/milestone-status.txt`:
+Update `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt`:
 
 - **Reset selected features** to `[ ]` pending with `Plan: (not yet planned)` -- their previous plans are invalidated by the scope change
 - **Preserve unselected features'** status and plan paths -- completed features keep `[x]`, in-progress features keep `[~]`, pending features keep `[ ]`
@@ -81,7 +81,7 @@ Update `milestones/<NN>-<name>/milestone-status.txt`:
 Update the milestone summary line in the `## Milestones` section of `progress.txt`:
 
 ```
-[ ] Milestone NN: Name  milestones/<NN>-<name>/  N/M features complete
+[ ] Milestone NN: Name  .project/{slug}/milestones/<NN>-<name>/  N/M features complete
 ```
 
 Recalculate N (completed features) and M (total features) based on the updated `milestone-status.txt`.

--- a/skills/project/plan-feature/SKILL.md
+++ b/skills/project/plan-feature/SKILL.md
@@ -40,16 +40,18 @@ entry in `milestone-status.txt` from `[ ]` to `[~] planned, awaiting build`.
 - Working directory is the project root (where `progress.txt` lives).
 - `progress.txt` must exist. If not, instruct user to run `/project` first.
 - An active milestone must exist. Validate: at least one milestone directory
-  exists under `milestones/` with a `milestone-status.txt` file. Do NOT check
+  exists under `.project/<slug>/milestones/` with a `milestone-status.txt` file. Do NOT check
   for `[x] Gate 3` -- Gate 3 stays `[~] In progress` and is never marked `[x]`
   until `/project` closes it.
 
 ## Step 1 -- Detect Mode and State
 
-Read `progress.txt` from the project root.
+Read `progress.txt` from the project root. Parse `# Project-ID: <slug>` from the
+header and construct the artifact base path: `.project/<slug>/`. If the header is
+missing, report the error and tell the user to run `/project` first.
 
 Prerequisite check: Verify an active milestone exists. If no milestone
-directories exist under `milestones/`, inform user: "No milestones have been
+directories exist under `.project/<slug>/milestones/`, inform user: "No milestones have been
 defined. Run /milestone to create a milestone first." Do not proceed.
 
 Auto-detect active milestone (D-02): Read `progress.txt`, find first milestone
@@ -62,7 +64,7 @@ Mode detection -- 3 branches:
 1. **Normal mode:** Target feature is at `[ ]` pending and has no plan file, OR
    user explicitly targets a pending feature --> proceed to Step 2.
 2. **Re-plan mode (D-04):** Target feature already has a plan file on disk
-   (auto-detected by checking `milestones/<NN>-<name>/plans/<feature-slug>.md`
+   (auto-detected by checking `.project/<slug>/milestones/<NN>-<name>/plans/<feature-slug>.md`
    existence) --> proceed to Step 4.
 3. **All features planned (D-03):** All features in the active milestone are at
    `[~]` planned or `[x]` complete. Report: "All features in milestone {NN}:
@@ -79,7 +81,7 @@ Follow the Input Loading and Codebase Scan Sub-Agent sections of the
 gate-4-plan specification to:
 
 1. Read all primary inputs (PLAN-01): milestone README, prd.md,
-   ARCHITECTURE_AND_DESIGN.md, progress.txt, milestone-status.txt.
+   `.project/<slug>/docs/ARCHITECTURE_AND_DESIGN.md`, progress.txt, milestone-status.txt.
 2. Spawn sub-agent for targeted codebase scan (D-10): scan files relevant to
    the target feature (5-15 files, not architecture-wide).
 3. If user referenced spike artifacts: read those specific files (D-11).
@@ -124,8 +126,8 @@ Display summary:
 FEATURE PLANNED: [Feature NN.N: Name]  (or FEATURE RE-PLANNED)
 
 ARTIFACTS CREATED:  (or ARTIFACTS UPDATED)
-- milestones/<NN>-<name>/plans/<feature-slug>.md
-- milestones/<NN>-<name>/reviews/gate-4-<feature-slug>-review.md
+- .project/<slug>/milestones/<NN>-<name>/plans/<feature-slug>.md
+- .project/<slug>/milestones/<NN>-<name>/reviews/gate-4-<feature-slug>-review.md
 
 STATE UPDATED:
 - milestone-status.txt (feature: [~] planned, awaiting build)

--- a/skills/project/plan-feature/references/gate-4-plan.md
+++ b/skills/project/plan-feature/references/gate-4-plan.md
@@ -2,19 +2,21 @@
 
 Produces per-feature implementation plans from an approved milestone definition and architecture document. This reference contains the complete Gate 4 specification for normal mode -- an executor reading only this file can run the full Gate 4 flow.
 
+`{slug}` is read from the `# Project-ID: <slug>` header in `progress.txt` at session start. All artifact paths in this document use `.project/{slug}/` as the base path.
+
 ## Input Loading (PLAN-01)
 
 Read the primary inputs from disk:
 
 1. **Read `progress.txt`** from the project root. This is required -- if it does not exist, report the error and stop. Used to validate that an active milestone exists.
-2. **Read milestone `README.md`** at `milestones/<NN>-<name>/README.md`. This is required -- primary source of feature details, acceptance criteria, and milestone context.
-3. **Read `milestones/<NN>-<name>/milestone-status.txt`**. This is required -- provides current feature statuses (pending, planned, in progress, complete).
+2. **Read milestone `README.md`** at `.project/{slug}/milestones/<NN>-<name>/README.md`. This is required -- primary source of feature details, acceptance criteria, and milestone context.
+3. **Read `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt`**. This is required -- provides current feature statuses (pending, planned, in progress, complete).
 4. **Read `prd.md`** from the project root. This is required -- provides project context, goals, non-goals, and scope.
-5. **Read `docs/ARCHITECTURE_AND_DESIGN.md`** from the project root. This is required -- provides architecture constraints, component inventory, data flow, and design decisions.
+5. **Read `.project/{slug}/docs/ARCHITECTURE_AND_DESIGN.md`** from the project root. This is required -- provides architecture constraints, component inventory, data flow, and design decisions.
 
 All five files are primary inputs. The milestone README provides feature descriptions and acceptance criteria. The PRD provides project-level context. The architecture document provides technical constraints and patterns. The progress and milestone-status files provide current state.
 
-**Spike artifacts (D-11):** Do not auto-detect or auto-scan `docs/spikes/`. Read spike docs ONLY when the user explicitly references them (e.g., "see the websocket auth spike"). Spike artifacts are user-referenced only.
+**Spike artifacts (D-11):** Do not auto-detect or auto-scan `.project/{slug}/docs/spikes/`. Read spike docs ONLY when the user explicitly references them (e.g., "see the websocket auth spike"). Spike artifacts are user-referenced only.
 
 ## Milestone and Feature Detection (PLAN-02, D-01, D-02, D-03)
 
@@ -26,7 +28,7 @@ Read `progress.txt` and find the first milestone at `[ ]` (pending) or `[~]` (in
 
 **User override:** The user can target a specific milestone by saying "plan a feature in milestone 3" or similar. Honor the override if the target milestone directory exists on disk with a `milestone-status.txt`.
 
-**Important:** Do NOT check for `[x] Gate 3` in progress.txt. Gate 3 stays `[~] In progress` -- it is never `[x]` until `/project` closes it. Validate that an active milestone exists (milestone directory exists with `milestone-status.txt`), not that Gate 3 is approved.
+**Important:** Do NOT check for `[x] Gate 3` in progress.txt. Gate 3 stays `[~] In progress` -- it is never `[x]` until `/project` closes it. Validate that an active milestone exists (`.project/{slug}/milestones/<NN>-<name>/` directory exists with `milestone-status.txt`), not that Gate 3 is approved.
 
 ### Auto-Select Next Unplanned Feature (D-01)
 
@@ -63,7 +65,7 @@ The sub-agent results inform the Approach, Files to Create/Modify, Interface Con
 
 ## Plan Generation (PLAN-03)
 
-Generate the feature plan file at `milestones/<NN>-<name>/plans/<feature-slug>.md` using `assets/feature-plan-template.md`.
+Generate the feature plan file at `.project/{slug}/milestones/<NN>-<name>/plans/<feature-slug>.md` using `assets/feature-plan-template.md`.
 
 **Feature slug:** Kebab-case derived from the feature name. Examples:
 - "User Registration" -> `user-registration.md`
@@ -73,7 +75,7 @@ Generate the feature plan file at `milestones/<NN>-<name>/plans/<feature-slug>.m
 **Create the plans directory if it does not exist:**
 
 ```bash
-mkdir -p milestones/<NN>-<name>/plans/
+mkdir -p .project/{slug}/milestones/<NN>-<name>/plans/
 ```
 
 Populate all 12 sections of the template using information from:
@@ -146,7 +148,7 @@ This is simpler than the section-by-section approval used in `/design` and `/mil
 
 ## Review Checklist Generation (PLAN-05)
 
-Generate the review checklist at `milestones/<NN>-<name>/reviews/gate-4-<feature-slug>-review.md` using `references/review-checklist-template.md`.
+Generate the review checklist at `.project/{slug}/milestones/<NN>-<name>/reviews/gate-4-<feature-slug>-review.md` using `references/review-checklist-template.md`.
 
 The feature slug in the filename matches the plan file slug (e.g., if the plan is `user-registration.md`, the review is `gate-4-user-registration-review.md`).
 
@@ -154,7 +156,7 @@ The feature slug in the filename matches the plan file slug (e.g., if the plan i
 
 Claude pre-checks items it can verify programmatically:
 
-- Plan file exists at expected path (`milestones/<NN>-<name>/plans/<feature-slug>.md`)
+- Plan file exists at expected path (`.project/{slug}/milestones/<NN>-<name>/plans/<feature-slug>.md`)
 - All 12 required sections present in the plan (Summary, Acceptance Criteria, Approach, Sub-Features, Interface Contracts, Edge Cases, Test Command, Test Strategy, Documentation, Files to Create/Modify, Dependencies, Architectural Deviations)
 - `milestone-status.txt` exists for the target milestone
 - Feature exists in `milestone-status.txt`
@@ -178,7 +180,7 @@ Before:
 After:
 ```
 [ ] Feature 01.1: User Registration
-    Plan: milestones/01-core-auth/plans/user-registration.md
+    Plan: .project/{slug}/milestones/01-core-auth/plans/user-registration.md
 ```
 
 ### On Gate 4 Approval (PLAN-09)
@@ -187,7 +189,7 @@ Update the feature marker in `milestone-status.txt` from `[ ]` to `[~] planned, 
 
 ```
 [~] Feature 01.1: User Registration
-    Plan: milestones/01-core-auth/plans/user-registration.md
+    Plan: .project/{slug}/milestones/01-core-auth/plans/user-registration.md
     Sub-features: 0/3 complete
 ```
 

--- a/skills/project/plan-feature/references/progress-format.md
+++ b/skills/project/plan-feature/references/progress-format.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The project pipeline uses plain-text checkbox notation across two tiers of state files: a project-level `progress.txt` at the project root (tracking gate approvals, milestone summaries, and spike entries) and milestone-level `milestone-status.txt` files at `milestones/<NN>-<name>/milestone-status.txt` (tracking per-feature details, sub-feature checklists, and notes). Both files use the same four-marker status notation defined below. This format was chosen over YAML for superior write-safety, token efficiency (~53% fewer tokens), and human editability (see DESIGN.md DD-3, progress-file/TEXT_vs_YAML_REPORT.md).
+The project pipeline uses plain-text checkbox notation across two tiers of state files: a project-level `progress.txt` at the project root (tracking gate approvals, milestone summaries, and spike entries) and milestone-level `milestone-status.txt` files at `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt` (tracking per-feature details, sub-feature checklists, and notes). Both files use the same four-marker status notation defined below. This format was chosen over YAML for superior write-safety, token efficiency (~53% fewer tokens), and human editability (see DESIGN.md DD-3, progress-file/TEXT_vs_YAML_REPORT.md).
 
 ## Status Notation
 
@@ -106,10 +106,10 @@ The artifact path on approved entries is the primary deliverable of that gate. `
 One line per milestone in the `## Milestones` section:
 
 ```
-[ ] Milestone 01: Core Auth  milestones/01-core-auth/  0/3 features complete
+[ ] Milestone 01: Core Auth  .project/{slug}/milestones/01-core-auth/  0/3 features complete
 ```
 
-Format: `[status] Milestone NN: Name  milestones/<NN>-<name>/  N/M features complete`
+Format: `[status] Milestone NN: Name  .project/{slug}/milestones/<NN>-<name>/  N/M features complete`
 
 Where:
 
@@ -138,7 +138,7 @@ Format: `[status] Spike Name  <artifact-path>` with an optional `Resolved: <date
 
 ## milestone-status.txt Format
 
-Per-milestone file located at `milestones/<NN>-<name>/milestone-status.txt`. Uses the same checkbox notation as `progress.txt` (per STATE-02). Contains detailed feature tracking for a single milestone.
+Per-milestone file located at `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt`. Uses the same checkbox notation as `progress.txt` (per STATE-02). Contains detailed feature tracking for a single milestone.
 
 ```
 # Milestone 01: Core Auth
@@ -147,11 +147,11 @@ Per-milestone file located at `milestones/<NN>-<name>/milestone-status.txt`. Use
 ## Features
 
 [x] Feature 01.1: User Registration
-    Plan: milestones/01-core-auth/plans/user-registration.md
+    Plan: .project/{slug}/milestones/01-core-auth/plans/user-registration.md
     Sub-features: 3/3 complete
 
 [~] Feature 01.2: Session Management
-    Plan: milestones/01-core-auth/plans/session-management.md
+    Plan: .project/{slug}/milestones/01-core-auth/plans/session-management.md
     Sub-features: 1/4 complete
     Notes: Switched from JWT to session cookies (see architectural deviation)
 

--- a/skills/project/plan-feature/references/revision-mode.md
+++ b/skills/project/plan-feature/references/revision-mode.md
@@ -4,7 +4,7 @@ Handles changes to an existing feature plan by selectively revising affected sec
 
 ## Entry Condition (D-04)
 
-Revision mode is entered when the target feature already has a plan file on disk. SKILL.md auto-detects this by checking whether `milestones/<NN>-<name>/plans/<feature-slug>.md` exists.
+Revision mode is entered when the target feature already has a plan file on disk. SKILL.md auto-detects this by checking whether `.project/{slug}/milestones/<NN>-<name>/plans/<feature-slug>.md` exists.
 
 If the plan file does not exist, this is not re-plan mode -- use `references/gate-4-plan.md` for normal mode.
 
@@ -12,9 +12,9 @@ If the plan file does not exist, this is not re-plan mode -- use `references/gat
 
 Read the existing feature plan and related artifacts from disk:
 
-1. **Read `milestones/<NN>-<name>/plans/<feature-slug>.md`** -- the existing feature plan with all 12 sections.
-2. **Read `milestones/<NN>-<name>/README.md`** -- the current milestone definition with acceptance criteria.
-3. **Read `milestones/<NN>-<name>/milestone-status.txt`** -- the current feature status (pending, planned, in progress, complete).
+1. **Read `.project/{slug}/milestones/<NN>-<name>/plans/<feature-slug>.md`** -- the existing feature plan with all 12 sections.
+2. **Read `.project/{slug}/milestones/<NN>-<name>/README.md`** -- the current milestone definition with acceptance criteria.
+3. **Read `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt`** -- the current feature status (pending, planned, in progress, complete).
 
 All three files are required. If any is missing, report the error and stop.
 
@@ -71,14 +71,14 @@ Update `milestone-status.txt` based on the feature's current status:
 
    ```
    [ ] Feature 01.1: User Registration
-       Plan: milestones/01-core-auth/plans/user-registration.md
+       Plan: .project/{slug}/milestones/01-core-auth/plans/user-registration.md
    ```
 
 2. **After re-approval:** Update back to `[~] planned, awaiting build`:
 
    ```
    [~] Feature 01.1: User Registration
-       Plan: milestones/01-core-auth/plans/user-registration.md
+       Plan: .project/{slug}/milestones/01-core-auth/plans/user-registration.md
        Sub-features: 0/3 complete
    ```
 

--- a/skills/project/references/progress-format.md
+++ b/skills/project/references/progress-format.md
@@ -22,6 +22,7 @@ The exact `progress.txt` content created by `/project` on first run (the only ti
 ```
 # Progress: <Project Name>
 # Created: <ISO date>
+# Project-ID: <slug>
 # Status: [ ] pending  [~] in progress  [x] complete  [-] skipped
 
 ## Gates
@@ -44,14 +45,48 @@ The exact `progress.txt` content created by `/project` on first run (the only ti
 Notes:
 
 - `<Project Name>` is derived from the project directory name or user input at bootstrap time.
+- `<slug>` is the slugified form of the project name — see Slug Derivation Rules below.
 - `<ISO date>` is the current date in YYYY-MM-DD format.
 - The `# Status:` header line serves as an inline legend for anyone reading the file.
+
+## Slug Derivation Rules
+
+The `# Project-ID:` value is a URL-safe slug derived from the project name. All skills read this value to compute the artifact base path (`.project/<slug>/`).
+
+Derivation steps (apply in order):
+
+1. Lowercase the entire string.
+2. Replace any character that is not a letter, digit, or space with a space.
+3. Collapse consecutive spaces into a single space and trim leading/trailing spaces.
+4. Replace spaces with hyphens.
+5. If the result is empty (e.g., the name was entirely punctuation), use `untitled-project` as the fallback slug.
+
+The final slug must match `^[a-z0-9]+(-[a-z0-9]+)*$`. Note: hyphens are separators produced by the derivation process, not characters preserved from the original name directly (though a hyphen in the original becomes a space in step 2 and a hyphen again in step 4).
+
+Examples:
+
+| Project Name | Slug |
+|---|---|
+| My Web App | `my-web-app` |
+| OCC Agentic AI | `occ-agentic-ai` |
+| E-Commerce Platform! | `e-commerce-platform` |
+| `api_v2 (internal)` | `api-v2-internal` |
+| `!!!` | `untitled-project` |
+
+Parsing instruction for skills: find the line starting with `# Project-ID:`, split on `: `, and use the second part as the slug. Construct the artifact base path as `.project/<slug>/`.
 
 ## Greenfield Bootstrap Variant
 
 When the project is greenfield (empty directory or boilerplate-only, per DD-10), Gate 0 is recorded as skipped in the bootstrap template instead of pending:
 
 ```
+# Progress: <Project Name>
+# Created: <ISO date>
+# Project-ID: <slug>
+# Status: [ ] pending  [~] in progress  [x] complete  [-] skipped
+
+## Gates
+
 [-] Gate 0: Codebase Alignment  Skipped (greenfield)
 ```
 
@@ -179,6 +214,7 @@ Note: `/project` itself only writes at bootstrap (PROJ-10), so this contract app
 Instructions for the LLM reading these files:
 
 - Lines starting with `#` are headers or comments (the `# Status:` line is a legend, not data)
+- `# Project-ID:` is the third header line (after `# Progress:` and `# Created:`); its value is the slug used to construct `.project/<slug>/`
 - Status is determined by the bracket marker at the start of each entry line (`[x]`, `[~]`, `[ ]`, `[-]`)
 - Artifact paths follow the date on approved gate entries
 - Feature counts in milestone summaries are `N/M` format where N=complete, M=total

--- a/skills/project/references/progress-format.md
+++ b/skills/project/references/progress-format.md
@@ -99,7 +99,7 @@ Gate entries appear in the `## Gates` section, one per line. The format varies b
 **Approved:**
 
 ```
-[x] Gate 0: Codebase Alignment  Approved: 2026-03-15  docs/codebase-assessment.md
+[x] Gate 0: Codebase Alignment  Approved: 2026-03-15  .project/<slug>/docs/codebase-assessment.md
 ```
 
 Format: `[x] Gate N: Name  Approved: <YYYY-MM-DD>  <artifact-path>`

--- a/skills/project/references/progress-format.md
+++ b/skills/project/references/progress-format.md
@@ -73,7 +73,7 @@ Examples:
 | `api_v2 (internal)` | `api-v2-internal` |
 | `!!!` | `untitled-project` |
 
-Parsing instruction for skills: find the line starting with `# Project-ID:`, split on `: `, and use the second part as the slug. Construct the artifact base path as `.project/<slug>/`.
+Parsing instruction for skills: find the line starting with `# Project-ID:`, split on the first `:`, take everything after it, and trim whitespace to get the slug. Construct the artifact base path as `.project/<slug>/`.
 
 ## Greenfield Bootstrap Variant
 

--- a/skills/project/references/routing-logic.md
+++ b/skills/project/references/routing-logic.md
@@ -13,7 +13,7 @@ The state-to-action table below covers every reachable project state. The skill 
 | No `progress.txt` | Bootstrap (internal -- do not route to another skill) | -- |
 | Gate WB is `[ ] Pending` | Resolve Gate WB: offer Yes/Skip/Defer (per D-08) | -- |
 | No gates approved (all `[ ]`) | Run `/define` to begin codebase assessment | -- |
-| Gate 0 approved, Gate WB not offered yet, no `docs/working-backwards.md`, customer outcome unclear | Offer Gate WB (per D-08, DD-11) | `/define` (continue to Gate 1) |
+| Gate 0 approved, Gate WB not offered yet, no `.project/{slug}/docs/working-backwards.md`, customer outcome unclear | Offer Gate WB (per D-08, DD-11) | `/define` (continue to Gate 1) |
 | Gate 0 approved, Gate WB resolved (`[x]` or `[-]`), no Gate 1 | Run `/define` to continue PRD interview | -- |
 | Gate 1 approved, no Gate 2 | Run `/design` to create architecture | `/spike` |
 | Gate 2 approved, no milestones defined | Run `/milestone` to define first milestone | `/spike` |
@@ -69,7 +69,7 @@ Per D-08 and DD-11, Gate WB (Working Backwards) is an optional stage that `/proj
 
 **Evaluation sequence:**
 
-1. Check if `docs/working-backwards.md` exists on disk.
+1. Check if `.project/{slug}/docs/working-backwards.md` exists on disk (path derived from the `# Project-ID: <slug>` header in `progress.txt`).
 2. Check the Gate WB line in `progress.txt`.
 3. Apply the appropriate action based on state:
 
@@ -116,12 +116,12 @@ Per PROJ-05 and D-07, `/project` validates that milestone summaries in `progress
 **Process:**
 
 1. For each milestone entry in the `## Milestones` section of `progress.txt`, extract the milestone directory path and the `N/M features complete` count.
-2. Read the corresponding `milestones/<NN>-<name>/milestone-status.txt`.
+2. Read the corresponding `milestone-status.txt` at `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt` (path derived from the milestone summary line, resolved against the artifact base path).
 3. Count the `[x]` feature entries in `milestone-status.txt`. Compare to the `N` (completed) and `M` (total) values in the `progress.txt` milestone summary line.
 4. If the counts diverge, emit an inline warning after the milestone entry in the status report:
 
 ```
-[~] Milestone 01: Core Auth  milestones/01-core-auth/  2/3 features complete
+[~] Milestone 01: Core Auth  .project/my-project/milestones/01-core-auth/  2/3 features complete
      Warning: Milestone status divergence detected -- progress.txt says 2/3, milestone-status.txt shows 1/3. Please acknowledge to continue routing.
 ```
 

--- a/skills/project/references/status-report-format.md
+++ b/skills/project/references/status-report-format.md
@@ -33,11 +33,11 @@ Checklist of all gates with their current status, approval dates, and artifact p
 
 ```
 GATES:
-  [x] Gate 0: Codebase Alignment    Approved: 2026-03-15  docs/codebase-assessment.md
+  [x] Gate 0: Codebase Alignment    Approved: 2026-03-15  .project/my-project/docs/codebase-assessment.md
   [-] Gate WB: Working Backwards    Skipped
   [x] Gate 1: Scope Review          Approved: 2026-03-16  prd.md
        Warning: Artifact not found: prd.md
-  [x] Gate 2: Design Review         Approved: 2026-03-17  docs/ARCHITECTURE_AND_DESIGN.md
+  [x] Gate 2: Design Review         Approved: 2026-03-17  .project/my-project/docs/ARCHITECTURE_AND_DESIGN.md
   [~] Gate 3: Milestone Review      In progress
 ```
 

--- a/skills/project/spike/SKILL.md
+++ b/skills/project/spike/SKILL.md
@@ -13,8 +13,8 @@ disable-model-invocation: true
 
 Accepts a research question and available tooling list, spawns sequential
 research and red-team agents, and produces a structured spike artifact at
-`docs/spikes/<topic>.md`. Supports follow-up research on existing spikes
-and lifecycle tracking in `progress.txt`.
+`.project/{project-slug}/docs/spikes/<topic>.md`. Supports follow-up
+research on existing spikes and lifecycle tracking in `progress.txt`.
 
 ## Rules
 
@@ -39,7 +39,12 @@ and lifecycle tracking in `progress.txt`.
 
 ## Step 1 -- Gather Input and Detect Mode
 
-Read `progress.txt` from the project root.
+Read `progress.txt` from the project root. Find the line starting with
+`# Project-ID:`, take the value after `:`, trim whitespace, and use it as
+`{project-slug}`. Construct the artifact base path:
+`.project/{project-slug}/`. All artifact reads and writes in this skill use
+this base path. If the header is missing, report the error and tell the
+user to run `/project` to re-bootstrap.
 
 Gather the user's research question and available tooling list per
 D-05/SPIKE-01. If the user provided these in their invocation message, use
@@ -49,8 +54,8 @@ them directly. If not provided, use `AskUserQuestion` to ask for:
 
 **Follow-up mode detection (SPIKE-05):**
 Read `references/spike-format.md` for the Topic Slug Generation rules.
-Generate the slug from the topic. Check if `docs/spikes/{slug}.md` exists
-on disk.
+Generate the slug from the topic. Check if
+`.project/{project-slug}/docs/spikes/{slug}.md` exists on disk.
 - If file exists: enter follow-up mode (Step 5).
 - If file does not exist: enter new spike mode (Step 2).
 - If slug collision (file exists but different question): use
@@ -87,7 +92,8 @@ Read `references/spike-format.md` for the artifact template and assembly
 instructions.
 
 Follow the assembly instructions to:
-1. Create `docs/spikes/` directory if it does not exist.
+1. Create `.project/{project-slug}/docs/spikes/` directory if it does not
+   exist.
 2. Build the spike artifact using the New Spike Template.
 3. Populate sections from agent outputs: Methodology and Findings from
    research findings, Red-Team Assessment from red-team findings (per D-10:
@@ -96,13 +102,13 @@ Follow the assembly instructions to:
    remaining risks after red-team review (per D-11).
 5. Set Status to `open`.
 6. Set Follow-Up Log to `(no follow-ups yet)`.
-7. Write the artifact to `docs/spikes/{slug}.md`.
+7. Write the artifact to `.project/{project-slug}/docs/spikes/{slug}.md`.
 
 **Update progress.txt (SPIKE-04, D-07):**
 Read `references/progress-format.md` for spike entry format. Add a `[ ]`
 entry under `## Spikes` in `progress.txt`. If `(none yet)` placeholder
 exists, replace it with the entry.
-Format: `[ ] {Spike Name}  docs/spikes/{slug}.md`
+Format: `[ ] {Spike Name}  .project/{project-slug}/docs/spikes/{slug}.md`
 
 Proceed to Step 6 (Completion Report).
 
@@ -115,13 +121,15 @@ agents (Steps 2-3) with the follow-up question as the research question
 and the same available tooling from the original spike.
 
 After both agents complete:
-1. Read the existing spike artifact from `docs/spikes/{slug}.md`.
+1. Read the existing spike artifact from
+   `.project/{project-slug}/docs/spikes/{slug}.md`.
 2. Append a new Follow-Up Log entry per the dated entry format (per D-08,
    D-12).
 3. If `(no follow-ups yet)` placeholder exists, replace it with the entry.
 4. Preserve all original content -- never overwrite findings, red-team
    assessment, or prior follow-ups.
-5. Write the updated artifact back to `docs/spikes/{slug}.md`.
+5. Write the updated artifact back to
+   `.project/{project-slug}/docs/spikes/{slug}.md`.
 
 **Offer resolution (SPIKE-06, D-07, D-08):**
 Use `AskUserQuestion` with options: **Resolved** (mark spike resolved) /
@@ -137,9 +145,9 @@ If "Done": Leave spike open, proceed to completion report.
 ## Step 6 -- Completion Report
 
 Display summary showing: spike name, artifact path
-(`docs/spikes/{slug}.md`), state update (`progress.txt` entry
-added/updated), and next action suggestion (review artifact or run
-`/project` for status).
+(`.project/{project-slug}/docs/spikes/{slug}.md`), state update
+(`progress.txt` entry added/updated), and next action suggestion (review
+artifact or run `/project` for status).
 
 If follow-ups were recorded, show count. If resolved, show resolution date.
 
@@ -151,7 +159,7 @@ If follow-ups were recorded, show count. If resolved, show resolution date.
   input (user provides findings directly).
 - **Red-team agent failure:** Report failure. Offer retry or skip red-team
   (note in artifact that red-team was not performed).
-- **Missing docs/spikes/ directory:** Create it automatically.
+- **Missing `.project/{project-slug}/docs/spikes/` directory:** Create it automatically.
 - **Spike artifact write failure:** Report error, display artifact content
   so user can save manually.
 - **Interrupted session:** User can re-invoke `/spike`. For new spikes, if

--- a/skills/project/spike/SKILL.md
+++ b/skills/project/spike/SKILL.md
@@ -13,7 +13,7 @@ disable-model-invocation: true
 
 Accepts a research question and available tooling list, spawns sequential
 research and red-team agents, and produces a structured spike artifact at
-`.project/{project-slug}/docs/spikes/<topic>.md`. Supports follow-up
+`.project/{slug}/docs/spikes/<topic>.md`. Supports follow-up
 research on existing spikes and lifecycle tracking in `progress.txt`.
 
 ## Rules
@@ -41,8 +41,8 @@ research on existing spikes and lifecycle tracking in `progress.txt`.
 
 Read `progress.txt` from the project root. Find the line starting with
 `# Project-ID:`, take the value after `:`, trim whitespace, and use it as
-`{project-slug}`. Construct the artifact base path:
-`.project/{project-slug}/`. All artifact reads and writes in this skill use
+`{slug}`. Construct the artifact base path:
+`.project/{slug}/`. All artifact reads and writes in this skill use
 this base path. If the header is missing, report the error and tell the
 user to run `/project` to re-bootstrap.
 
@@ -55,7 +55,7 @@ them directly. If not provided, use `AskUserQuestion` to ask for:
 **Follow-up mode detection (SPIKE-05):**
 Read `references/spike-format.md` for the Topic Slug Generation rules.
 Generate the slug from the topic. Check if
-`.project/{project-slug}/docs/spikes/{slug}.md` exists on disk.
+`.project/{slug}/docs/spikes/{topic-slug}.md` exists on disk.
 - If file exists: enter follow-up mode (Step 5).
 - If file does not exist: enter new spike mode (Step 2).
 - If slug collision (file exists but different question): use
@@ -92,7 +92,7 @@ Read `references/spike-format.md` for the artifact template and assembly
 instructions.
 
 Follow the assembly instructions to:
-1. Create `.project/{project-slug}/docs/spikes/` directory if it does not
+1. Create `.project/{slug}/docs/spikes/` directory if it does not
    exist.
 2. Build the spike artifact using the New Spike Template.
 3. Populate sections from agent outputs: Methodology and Findings from
@@ -102,13 +102,13 @@ Follow the assembly instructions to:
    remaining risks after red-team review (per D-11).
 5. Set Status to `open`.
 6. Set Follow-Up Log to `(no follow-ups yet)`.
-7. Write the artifact to `.project/{project-slug}/docs/spikes/{slug}.md`.
+7. Write the artifact to `.project/{slug}/docs/spikes/{topic-slug}.md`.
 
 **Update progress.txt (SPIKE-04, D-07):**
 Read `references/progress-format.md` for spike entry format. Add a `[ ]`
 entry under `## Spikes` in `progress.txt`. If `(none yet)` placeholder
 exists, replace it with the entry.
-Format: `[ ] {Spike Name}  .project/{project-slug}/docs/spikes/{slug}.md`
+Format: `[ ] {Spike Name}  .project/{slug}/docs/spikes/{topic-slug}.md`
 
 Proceed to Step 6 (Completion Report).
 
@@ -122,14 +122,14 @@ and the same available tooling from the original spike.
 
 After both agents complete:
 1. Read the existing spike artifact from
-   `.project/{project-slug}/docs/spikes/{slug}.md`.
+   `.project/{slug}/docs/spikes/{topic-slug}.md`.
 2. Append a new Follow-Up Log entry per the dated entry format (per D-08,
    D-12).
 3. If `(no follow-ups yet)` placeholder exists, replace it with the entry.
 4. Preserve all original content -- never overwrite findings, red-team
    assessment, or prior follow-ups.
 5. Write the updated artifact back to
-   `.project/{project-slug}/docs/spikes/{slug}.md`.
+   `.project/{slug}/docs/spikes/{topic-slug}.md`.
 
 **Offer resolution (SPIKE-06, D-07, D-08):**
 Use `AskUserQuestion` with options: **Resolved** (mark spike resolved) /
@@ -145,7 +145,7 @@ If "Done": Leave spike open, proceed to completion report.
 ## Step 6 -- Completion Report
 
 Display summary showing: spike name, artifact path
-(`.project/{project-slug}/docs/spikes/{slug}.md`), state update
+(`.project/{slug}/docs/spikes/{topic-slug}.md`), state update
 (`progress.txt` entry added/updated), and next action suggestion (review
 artifact or run `/project` for status).
 
@@ -159,7 +159,7 @@ If follow-ups were recorded, show count. If resolved, show resolution date.
   input (user provides findings directly).
 - **Red-team agent failure:** Report failure. Offer retry or skip red-team
   (note in artifact that red-team was not performed).
-- **Missing `.project/{project-slug}/docs/spikes/` directory:** Create it automatically.
+- **Missing `.project/{slug}/docs/spikes/` directory:** Create it automatically.
 - **Spike artifact write failure:** Report error, display artifact content
   so user can save manually.
 - **Interrupted session:** User can re-invoke `/spike`. For new spikes, if

--- a/skills/project/spike/references/progress-format.md
+++ b/skills/project/spike/references/progress-format.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The project pipeline uses plain-text checkbox notation across two tiers of state files: a project-level `progress.txt` at the project root (tracking gate approvals, milestone summaries, and spike entries) and milestone-level `milestone-status.txt` files at `milestones/<NN>-<name>/milestone-status.txt` (tracking per-feature details, sub-feature checklists, and notes). Both files use the same four-marker status notation defined below. This format was chosen over YAML for superior write-safety, token efficiency (~53% fewer tokens), and human editability (see DESIGN.md DD-3, progress-file/TEXT_vs_YAML_REPORT.md).
+The project pipeline uses plain-text checkbox notation across two tiers of state files: a project-level `progress.txt` at the project root (tracking gate approvals, milestone summaries, and spike entries) and milestone-level `milestone-status.txt` files at `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt` (tracking per-feature details, sub-feature checklists, and notes). Both files use the same four-marker status notation defined below. This format was chosen over YAML for superior write-safety, token efficiency (~53% fewer tokens), and human editability (see DESIGN.md DD-3, progress-file/TEXT_vs_YAML_REPORT.md).
 
 ## Status Notation
 
@@ -112,10 +112,10 @@ The artifact path on approved entries is the primary deliverable of that gate. `
 One line per milestone in the `## Milestones` section:
 
 ```
-[ ] Milestone 01: Core Auth  milestones/01-core-auth/  0/3 features complete
+[ ] Milestone 01: Core Auth  .project/{slug}/milestones/01-core-auth/  0/3 features complete
 ```
 
-Format: `[status] Milestone NN: Name  milestones/<NN>-<name>/  N/M features complete`
+Format: `[status] Milestone NN: Name  .project/{slug}/milestones/<NN>-<name>/  N/M features complete`
 
 Where:
 
@@ -131,22 +131,22 @@ All spikes (open and resolved) appear in the `## Spikes` section, per decision D
 **Open spike:**
 
 ```
-[ ] WebSocket Auth Compatibility  .project/{project-slug}/docs/spikes/websocket-auth.md
+[ ] WebSocket Auth Compatibility  .project/{slug}/docs/spikes/websocket-auth.md
 ```
 
 **Resolved spike:**
 
 ```
-[x] SQLite to Postgres Migration  .project/{project-slug}/docs/spikes/sqlite-postgres.md  Resolved: 2026-03-17
+[x] SQLite to Postgres Migration  .project/{slug}/docs/spikes/sqlite-postgres.md  Resolved: 2026-03-17
 ```
 
 Format: `[status] Spike Name  <artifact-path>` with an optional `Resolved: <date>` suffix for completed spikes.
 
-The `{project-slug}` is read from the `# Project-ID:` header in `progress.txt` at the time the spike entry is written.
+The `{slug}` is read from the `# Project-ID:` header in `progress.txt` at the time the spike entry is written.
 
 ## milestone-status.txt Format
 
-Per-milestone file located at `milestones/<NN>-<name>/milestone-status.txt`. Uses the same checkbox notation as `progress.txt` (per STATE-02). Contains detailed feature tracking for a single milestone.
+Per-milestone file located at `.project/{slug}/milestones/<NN>-<name>/milestone-status.txt`. Uses the same checkbox notation as `progress.txt` (per STATE-02). Contains detailed feature tracking for a single milestone.
 
 ```
 # Milestone 01: Core Auth
@@ -155,11 +155,11 @@ Per-milestone file located at `milestones/<NN>-<name>/milestone-status.txt`. Use
 ## Features
 
 [x] Feature 01.1: User Registration
-    Plan: milestones/01-core-auth/plans/user-registration.md
+    Plan: .project/{slug}/milestones/01-core-auth/plans/user-registration.md
     Sub-features: 3/3 complete
 
 [~] Feature 01.2: Session Management
-    Plan: milestones/01-core-auth/plans/session-management.md
+    Plan: .project/{slug}/milestones/01-core-auth/plans/session-management.md
     Sub-features: 1/4 complete
     Notes: Switched from JWT to session cookies (see architectural deviation)
 

--- a/skills/project/spike/references/progress-format.md
+++ b/skills/project/spike/references/progress-format.md
@@ -22,6 +22,7 @@ The exact `progress.txt` content created by `/project` on first run (the only ti
 ```
 # Progress: <Project Name>
 # Created: <ISO date>
+# Project-ID: <slug>
 # Status: [ ] pending  [~] in progress  [x] complete  [-] skipped
 
 ## Gates
@@ -44,8 +45,13 @@ The exact `progress.txt` content created by `/project` on first run (the only ti
 Notes:
 
 - `<Project Name>` is derived from the project directory name or user input at bootstrap time.
+- `<slug>` is the slugified form of the project name (lowercase, hyphens, alphanumeric only).
 - `<ISO date>` is the current date in YYYY-MM-DD format.
 - The `# Status:` header line serves as an inline legend for anyone reading the file.
+
+Parsing instruction for skills: find the line starting with `# Project-ID:`, take the
+value after `:`, trim whitespace, and use it as `<slug>`. Construct the artifact base
+path as `.project/<slug>/`.
 
 ## Greenfield Bootstrap Variant
 
@@ -125,16 +131,18 @@ All spikes (open and resolved) appear in the `## Spikes` section, per decision D
 **Open spike:**
 
 ```
-[ ] WebSocket Auth Compatibility  docs/spikes/websocket-auth.md
+[ ] WebSocket Auth Compatibility  .project/{project-slug}/docs/spikes/websocket-auth.md
 ```
 
 **Resolved spike:**
 
 ```
-[x] SQLite to Postgres Migration  docs/spikes/sqlite-postgres.md  Resolved: 2026-03-17
+[x] SQLite to Postgres Migration  .project/{project-slug}/docs/spikes/sqlite-postgres.md  Resolved: 2026-03-17
 ```
 
 Format: `[status] Spike Name  <artifact-path>` with an optional `Resolved: <date>` suffix for completed spikes.
+
+The `{project-slug}` is read from the `# Project-ID:` header in `progress.txt` at the time the spike entry is written.
 
 ## milestone-status.txt Format
 

--- a/skills/project/spike/references/spike-format.md
+++ b/skills/project/spike/references/spike-format.md
@@ -1,6 +1,6 @@
 # Spike Artifact Format
 
-Defines the structure of spike artifacts produced at `docs/spikes/<topic>.md`. All spike artifacts use the same fixed section structure (D-09). The Red-Team Assessment is an EQUAL PEER section at the same level as Findings -- the two perspectives are never merged or suppressed (D-10). This ensures users see both the research and its independent critique as first-class information.
+Defines the structure of spike artifacts produced at `.project/{project-slug}/docs/spikes/<topic>.md`. All spike artifacts use the same fixed section structure (D-09). The Red-Team Assessment is an EQUAL PEER section at the same level as Findings -- the two perspectives are never merged or suppressed (D-10). This ensures users see both the research and its independent critique as first-class information.
 
 ## Topic Slug Generation
 
@@ -16,9 +16,9 @@ Convert the spike topic to a filename-safe slug:
 
 | Topic | Slug | File Path |
 |-------|------|-----------|
-| WebSocket Auth Compatibility | websocket-auth-compatibility | docs/spikes/websocket-auth-compatibility.md |
-| SQLite to Postgres Migration | sqlite-to-postgres-migration | docs/spikes/sqlite-to-postgres-migration.md |
-| React 19 vs Svelte 5 | react-19-vs-svelte-5 | docs/spikes/react-19-vs-svelte-5.md |
+| WebSocket Auth Compatibility | websocket-auth-compatibility | .project/{project-slug}/docs/spikes/websocket-auth-compatibility.md |
+| SQLite to Postgres Migration | sqlite-to-postgres-migration | .project/{project-slug}/docs/spikes/sqlite-to-postgres-migration.md |
+| React 19 vs Svelte 5 | react-19-vs-svelte-5 | .project/{project-slug}/docs/spikes/react-19-vs-svelte-5.md |
 
 This is consistent with milestone and feature slug patterns used elsewhere in the project.
 
@@ -95,7 +95,7 @@ The follow-up's research and red-team agents run the same full flow as the initi
 
 How the parent SKILL.md assembles the final spike artifact from agent outputs:
 
-1. **Create `docs/spikes/` directory** if it does not exist: `mkdir -p docs/spikes`
+1. **Create `.project/{project-slug}/docs/spikes/` directory** if it does not exist: `mkdir -p .project/{project-slug}/docs/spikes`
 
 2. **Read `/tmp/spike-research-findings.md`** for:
    - Methodology section content (from the research agent's Methodology section)
@@ -114,7 +114,7 @@ How the parent SKILL.md assembles the final spike artifact from agent outputs:
 
 6. **Set Follow-Up Log** to `(no follow-ups yet)`
 
-7. **Write the complete artifact** to `docs/spikes/<topic-slug>.md` using the New Spike Template
+7. **Write the complete artifact** to `.project/{project-slug}/docs/spikes/<topic-slug>.md` using the New Spike Template
 
 8. **Clean up temp files:** Remove `/tmp/spike-research-findings.md` and `/tmp/spike-redteam-findings.md`
 
@@ -126,11 +126,11 @@ Per D-07 and SPIKE-06, when the user signals that a spike is resolved:
 
 2. **Update progress.txt:** Change the spike entry from:
    ```
-   [ ] Spike Name  docs/spikes/<topic>.md
+   [ ] Spike Name  .project/{project-slug}/docs/spikes/<topic>.md
    ```
    to:
    ```
-   [x] Spike Name  docs/spikes/<topic>.md  Resolved: YYYY-MM-DD
+   [x] Spike Name  .project/{project-slug}/docs/spikes/<topic>.md  Resolved: YYYY-MM-DD
    ```
    where `YYYY-MM-DD` is the current date.
 


### PR DESCRIPTION
## Summary

- Adds a `# Project-ID: <slug>` header to `progress.txt` bootstrap so every skill can derive the artifact base path at runtime without hardcoding it
- Updates all project sub-skills (`/define`, `/design`, `/milestone`, `/plan-feature`, `/build`, `/spike`) to read and write artifacts under `.project/{slug}/` instead of `docs/` and `milestones/`
- Updates `/project` routing logic, status report format, and artifact validation to use the computed base path
- Updates skill documentation (`docs/skills/`) and codex skill docs to reflect new output paths

## Changes by feature

| Feature | Scope |
|---------|-------|
| Feature 1 | `progress.txt` bootstrap gains `Project-ID` slug header; `references/progress-format.md` documents slug rules |
| Feature 2 | `/project` SKILL.md, `routing-logic.md`, `status-report-format.md` — all paths use `.project/{slug}/` |
| Feature 3 | `/define` — codebase-assessment, working-backwards, reviews → `.project/{slug}/docs/` |
| Feature 4 | `/design` — ARCHITECTURE_AND_DESIGN.md, gate-2 review, refresh scan → `.project/{slug}/docs/` |
| Feature 5 | `/milestone` and `/plan-feature` — all milestone artifacts → `.project/{slug}/milestones/` |
| Feature 6 | `/build` — codebase refresh, feature plans, milestone-status.txt → `.project/{slug}/` |
| Feature 7 | `/spike` — spike docs → `.project/{slug}/docs/spikes/` |
| Feature 8 | `docs/skills/project.md`, `docs/skills/*.md`, `docs/codex-skills/project.md` updated |

## Breaking change

Existing projects using the old `docs/` and `milestones/` paths will need to move artifacts manually. No migration script is included — document this when onboarding existing projects.

## Test plan

- [ ] Bootstrap a new project with `/project` and verify `progress.txt` contains `# Project-ID: <slug>`
- [ ] Run `/define` and confirm artifacts land under `.project/{slug}/docs/`
- [ ] Run `/design` and confirm `ARCHITECTURE_AND_DESIGN.md` lands under `.project/{slug}/docs/`
- [ ] Run `/milestone` and confirm milestone folder is created under `.project/{slug}/milestones/`
- [ ] Run `/plan-feature` and confirm plan files land under `.project/{slug}/milestones/.../plans/`
- [ ] Run `/build` and confirm codebase-assessment refresh writes to `.project/{slug}/docs/`
- [ ] Run `/spike` and confirm spike doc lands under `.project/{slug}/docs/spikes/`
- [ ] Run `/project` status and verify displayed paths show `.project/{slug}/` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)