### PR TITLE
Upstream battle-tested Claude Code toolkit from occ-k8s-cluster-config

### DIFF
--- a/commands/investigate.md
+++ b/commands/investigate.md
@@ -21,7 +21,7 @@ Create a slug from the topic (e.g., `circular-dependency`, `aurora-connection-ti
 
 ### Step 2 — Create investigation file
 
-Write `agents/investigations/[slug].md`:
+Write `agents/investigations/[slug]/[slug].md`:
 
 ```markdown
 # Investigation: [Title]
@@ -77,14 +77,34 @@ Work through the theories systematically:
 3. **Record every test** in the Tests Performed table — even negative results are data
 4. **Update Facts and Theories** as you learn — promote confirmed theories to facts, eliminate disproven ones
 5. **Maintain 3+ hypotheses** — if you're down to one theory and it hasn't been confirmed, generate more
+6. **Codex review of the hypotheses** — once the Theories section holds 3+ competing hypotheses with
+   evidence and tests, and *before* you spend cycles running those tests, get an independent read on the
+   hypothesis set (see [Codex Review](#codex-review) below). Ask Codex for:
+   - hypotheses that are not actually distinct (same cause, different wording)
+   - hypotheses contradicted by the recorded Facts
+   - a missing hypothesis the recorded evidence supports
+   - tests that cannot discriminate between the listed theories
+
+   Fold valid findings back into Facts/Theories before testing. Record rejected findings with a
+   one-line reason. **Skip this substep entirely if codex is not available.**
 
 ### Step 4 — Resolve
 
 When the root cause is found:
 
 1. Fill in the Resolution section
-2. Change Status from `Active` to `Resolved`
-3. Report to the user:
+2. **Codex review of the resolution** — before closing, hand the completed investigation file to Codex
+   (see [Codex Review](#codex-review) below). Ask it to verify:
+   - the root cause is supported by the recorded Facts and Tests Performed, not asserted
+   - the fix addresses the root cause, not just the symptom
+   - no competing hypothesis was left un-eliminated
+   - Prevention is concrete and actionable, not a platitude
+
+   Address valid findings before closing. A root cause Codex shows is unsupported means the
+   investigation stays `Active` — go back to Step 3. **Skip this substep entirely if codex is not
+   available.**
+3. Change Status from `Active` to `Resolved`
+4. Report to the user:
 
 ```
 INVESTIGATION RESOLVED: [title]
@@ -92,17 +112,61 @@ INVESTIGATION RESOLVED: [title]
 Root cause: [one sentence]
 Fix: [what was changed]
 Prevention: [how to avoid in future]
+Codex review: [X valid / Y rejected — or "skipped (codex unavailable)"]
 
-Full investigation: agents/investigations/[slug].md
+Full investigation: agents/investigations/[slug]/[slug].md
 ```
 
 If the investigation is a **permanent learning** (likely to recur, non-obvious), suggest adding it to CLAUDE.md via the `/memory` command.
+
+## Codex Review
+
+Both review points (Step 3 hypotheses, Step 4 resolution) use the same mechanism. Codex is an
+independent engine — a second pass on reasoning the investigating context is blind to, which is
+exactly the confirmation bias the 3+ hypothesis rule exists to counter.
+
+**Availability guard — check first.** The review is optional tooling, not a gate:
+
+```bash
+command -v codex >/dev/null 2>&1
+```
+
+If codex is absent, or `.claude/scripts/codex-review.sh` is missing, **skip the review and
+continue**. Record `CODEX REVIEW: skipped (codex unavailable)` in the investigation file and say so
+in the report. Never block an investigation on review-tooling absence, and never infer a clean
+review from one that did not run.
+
+**Run it** with the hardened wrapper in file mode — do NOT hand-roll `codex exec` (an open stdin
+hangs the process, and a review must never run in a writable sandbox):
+
+```bash
+bash .claude/scripts/codex-review.sh \
+  agents/investigations/[slug]/[slug].md [implicated source files...] \
+  -p "This is a debugging investigation, not a code diff. Review the <Theories|Resolution> section against the recorded Facts and Tests Performed and the real source. <the bullet questions from the step>"
+```
+
+Pass the implicated source files alongside the investigation file so Codex can check claims against
+the code rather than trusting the write-up.
+
+Exit codes: `0` = PASS, `1` = FAIL (findings reported), **`2` = review failed (timeout / codex
+error) — treat as "no verdict", never infer PASS**. On exit 2, treat it as unavailable: record the
+reason and continue.
+
+Alternative: the `codex:codex-rescue` agent (harness-native, same engine) when the `codex` plugin is
+installed.
+
+**Triage every finding** — do not auto-apply Codex output into the investigation file:
+
+- **VALID** — reproducible against the recorded Facts/Tests or the real source
+- **REJECTED** — false positive, out of scope, or unsupported; record a one-line reason
+
+Record the triage outcome in the investigation file under the section that was reviewed.
 
 ## During Long Investigations
 
 - Update the investigation file as you go — don't accumulate findings only in conversation context
 - If context is getting high, the investigation file preserves your work across `/compact` or `/clear`
-- Reference the file path when reporting: "See agents/investigations/[slug].md for full details"
+- Reference the file path when reporting: "See agents/investigations/[slug]/[slug].md for full details"
 
 ## Important Rules
 

--- a/commands/start-feature-auto.md
+++ b/commands/start-feature-auto.md
@@ -7,7 +7,8 @@ description: Automated feature implementation. Reads project context, writes a s
 
 Reads project context, persists a structured plan to `progress.txt`, then implements the feature
 autonomously. All pre-work context is written to NOTES before implementation begins so the record
-is complete regardless of outcome.
+is complete regardless of outcome. After implementation, the completed change set is reviewed by
+Codex; findings judged valid are refactored and re-tested before the feature is closed.
 
 ## Rules
 
@@ -16,6 +17,10 @@ is complete regardless of outcome.
 - **Write NOTES before implementing** — context must be persisted before any code changes.
 - **Follow `docs/ARCHITECTURE_AND_DESIGN.md` for design decisions** — it is the authoritative
   spec; `prd.md` defines requirements and acceptance criteria.
+- **Codex-review before closing** — after implementation, run a Codex review of the completed
+  change set. Triage each finding yourself; refactor the ones you judge valid, then re-test.
+  Reality is the arbiter — do not apply a finding you cannot confirm against the code, and do not
+  close the feature on an unaddressed valid HIGH finding.
 - **Close the feature on completion** — update NOTES with the completion record and mark `[x]`.
 
 ## Step 1 — Read progress.txt
@@ -103,20 +108,76 @@ implements, runs tests, and returns. Apply the result.
 Each agent receives only its own scope. After all agents return, merge results and resolve any
 conflicts.
 
-## Step 7 — Close the feature
+## Step 7 — Codex review of the completed change set
 
-After implementation is complete:
+After implementation finishes and local tests/linters pass, review the work with Codex **before**
+closing the feature. Codex is an independent engine — a second pass that catches what the
+implementing context is blind to.
+
+1. **Assemble the change set.** Collect the diff for the feature's changed files (e.g.
+   `git --no-pager diff` for unstaged work, plus any new files). Capture the feature's acceptance
+   criteria from `prd.md` / `docs/ARCHITECTURE_AND_DESIGN.md`.
+
+2. **Write a review brief** to a scratchpad temp file: the change set (or the list of changed
+   files for Codex to read directly), the acceptance criteria, and the instruction to return
+   **severity-tagged** findings (`HIGH` / `MED` / `LOW`), each as `file:line — problem → fix`,
+   plus a one-line verdict. Ask Codex to verify against the real source, not the diff alone.
+
+3. **Run Codex** with the hardened wrapper — do NOT hand-roll `codex exec` (an open stdin hangs
+   the process, and a review must never run in a writable sandbox):
+
+   ```bash
+   bash .claude/scripts/codex-review.sh --diff \
+     -p "Acceptance criteria: <paste from brief>. Verify against the real source, not the diff alone."
+   ```
+
+   The wrapper reviews the working diff **plus untracked new files**, pipes the prompt on a closed
+   stdin (no hang), enforces a timeout, runs `-s read-only`, and returns severity-tagged findings
+   ending in `VERDICT: PASS` / `VERDICT: FAIL`. Exit 0 = PASS, 1 = FAIL, **2 = review failed
+   (timeout / codex error) — treat as "no verdict", never infer PASS**. For a commit-range or very
+   large review: `--commits <base>..HEAD -t 600`.
+
+   Alternative: the `codex:codex-rescue` agent (harness-native; same independent engine).
+
+4. **Triage every finding.** For each, decide and record:
+   - **VALID** — real, in-scope, and confirmed against the code (correctness, security, a missed
+     acceptance criterion, a second-order break).
+   - **REJECTED** — false positive, out of scope for this feature, or pure style with no behavior
+     change. Record a one-line reason.
+
+   Do not auto-apply Codex output. A finding you cannot reproduce in the code is REJECTED with that
+   noted. If unsure whether a finding is valid, re-read the implicated code before deciding.
+
+## Step 8 — Refactor on valid findings (conditional)
+
+- **No valid findings** (clean review, or only REJECTED findings): skip refactoring. Proceed to
+  Step 9 and record the review outcome.
+- **Valid findings exist:** address them using the same execution model recorded in NOTES (inline,
+  sub-agent, or team). Stay within the feature's scope — do not expand it. Prioritize HIGH
+  (correctness/security) over LOW (style). After refactoring:
+  1. Re-run the available tests and linters; they must pass.
+  2. Optionally re-run Codex **once** to confirm the valid findings are resolved (cap re-reviews at
+     one to avoid loops). If a valid HIGH finding remains unresolved after the refactor pass, do
+     **not** close — leave the feature `[~]` and report (see Error Handling).
+
+Record the review + refactor outcome in NOTES (the `CODEX REVIEW` / `REFACTOR` fields in Step 9).
+
+## Step 9 — Close the feature
+
+After implementation, Codex review, and any refactoring are complete:
 
 1. Append to the feature's NOTES block in `progress.txt`:
 
 ```
        CODE COMPLETE: [N files changed; tests: pass/fail; lint: pass/fail].
+       CODEX REVIEW: [N findings — H/M/L counts; X valid, Y rejected (one-line reasons)].
+       REFACTOR: [what changed to resolve valid findings; re-test result — or "none (review clean)"].
        Completed YYYY-MM-DD.
 ```
 
-2. Change the feature status from `[~]` to `[x]`.
+1. Change the feature status from `[~]` to `[x]`.
 
-3. Report to the user:
+2. Report to the user:
 
 ```
 COMPLETED: Feature X.Y — [Title]
@@ -124,6 +185,7 @@ COMPLETED: Feature X.Y — [Title]
 SUMMARY: [From NOTES]
 EXECUTION MODEL: [inline | sub-agent | team]
 FILES CHANGED: [list]
+CODEX REVIEW: [X valid / Y rejected; refactored: yes/no]
 NEXT FEATURE: Feature X.Z — [Title] (run /start-feature-auto to continue)
 ```
 
@@ -137,5 +199,11 @@ NEXT FEATURE: Feature X.Z — [Title] (run /start-feature-auto to continue)
   Report the failure with enough detail for the user to decide how to proceed.
 - **Implementation does not satisfy acceptance criteria:** Do not mark `[x]`. Record what is
   missing in NOTES under `CODE COMPLETE:`. Leave as `[~]` and report to the user.
+- **Codex unavailable or the review command fails:** Non-fatal. The implementation already passed
+  local tests. Record `CODEX REVIEW: skipped (codex unavailable — <reason>)` in NOTES, flag it
+  plainly in the report, and proceed to close. Do not block completion on review-tooling absence.
+- **Valid HIGH finding unresolved after the refactor pass:** Do not mark `[x]`. Record the finding
+  and the attempted fix in NOTES under `REFACTOR:`. Leave the feature `[~]` and report so the user
+  can decide how to proceed.
 - **Missing `docs/ARCHITECTURE_AND_DESIGN.md`:** Proceed using `prd.md` alone. Note the absence
   in NOTES.

--- a/commands/start-feature-auto.md
+++ b/commands/start-feature-auto.md
@@ -168,16 +168,16 @@ After implementation, Codex review, and any refactoring are complete:
 
 1. Append to the feature's NOTES block in `progress.txt`:
 
-```
-       CODE COMPLETE: [N files changed; tests: pass/fail; lint: pass/fail].
-       CODEX REVIEW: [N findings — H/M/L counts; X valid, Y rejected (one-line reasons)].
-       REFACTOR: [what changed to resolve valid findings; re-test result — or "none (review clean)"].
-       Completed YYYY-MM-DD.
-```
+   ```
+          CODE COMPLETE: [N files changed; tests: pass/fail; lint: pass/fail].
+          CODEX REVIEW: [N findings — H/M/L counts; X valid, Y rejected (one-line reasons)].
+          REFACTOR: [what changed to resolve valid findings; re-test result — or "none (review clean)"].
+          Completed YYYY-MM-DD.
+   ```
 
-1. Change the feature status from `[~]` to `[x]`.
+2. Change the feature status from `[~]` to `[x]`.
 
-2. Report to the user:
+3. Report to the user:
 
 ```
 COMPLETED: Feature X.Y — [Title]

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -8,9 +8,9 @@ For multi-file skill bundles (with scripts and references), see [SKILLS.md](SKIL
 
 | Command | Trigger | Purpose | Details |
 |---|---|---|---|
-| Create PRD | `/create-prd` | Guided interview to create PRD, architecture doc, and progress file | [View](commands/create-prd.md) |
+| Create PRD | `/create-prd` | Guided interview to create PRD, architecture doc, and progress file (ships as a skill — see `skills/create-prd/`) | [View](commands/create-prd.md) |
 | Start Feature | `/start-feature` | Begin the next feature from progress.txt — interactive, with human-in-the-loop review | [View](commands/start-feature.md) |
-| Start Feature (Auto) | `/start-feature-auto` | Automated feature implementation: writes plan to NOTES, implements without user checkpoint | [View](commands/start-feature-auto.md) |
+| Start Feature (Auto) | `/start-feature-auto` | Automated feature implementation: writes plan to NOTES, implements, then Codex-reviews the change set and refactors valid findings before closing | [View](commands/start-feature-auto.md) |
 | Catchup | `/catchup` | Read project state at start of a new session | [View](commands/catchup.md) |
 | Handoff | `/handoff` | Save session state before ending | [View](commands/handoff.md) |
 | Investigate | `/investigate` | Structured debugging investigation | [View](commands/investigate.md) |
@@ -47,7 +47,7 @@ Commands follow a development lifecycle. Use them in this order for new projects
     │
 /start-feature       Pick up the next feature (interactive — review plan, confirm to implement)
   OR
-/start-feature-auto  Pick up the next feature (autonomous — write plan to NOTES, implement)
+/start-feature-auto  Pick up the next feature (autonomous — plan to NOTES, implement, Codex review, refactor)
     │
   (implement)        Write the code
     │
@@ -79,7 +79,7 @@ Copy command files from `commands/` into `.claude/commands/` in the target repos
 
 ```bash
 # Copy individual commands
-cp commands/create-prd.md              <target-repo>/.claude/commands/
+cp -r skills/create-prd                <target-repo>/.claude/skills/   # /create-prd ships as a skill
 cp commands/start-feature.md           <target-repo>/.claude/commands/
 cp commands/start-feature-auto.md      <target-repo>/.claude/commands/
 cp commands/catchup.md                 <target-repo>/.claude/commands/

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -94,6 +94,17 @@ cp commands/dream.md                   <target-repo>/.claude/commands/
 
 Commands take effect immediately on the next Claude Code conversation in that repository.
 
+**Prerequisite for `/start-feature-auto`:** its Step 7 Codex review invokes
+`bash .claude/scripts/codex-review.sh`, which is installed by the Claude Toolkit bundle, not by
+copying the command:
+
+```bash
+bash scripts/claude-toolkit/install.sh <target-repo-path>
+```
+
+Without it the review step records `CODEX REVIEW: skipped (codex unavailable)` and the feature still
+closes — the command degrades rather than failing. See [SCRIPTS.md](SCRIPTS.md#claude-toolkit).
+
 ### Choosing Commands
 
 | Project Type | Recommended Commands |

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -15,7 +15,7 @@ Rules are always-on behavioral guidelines loaded automatically via `.claude/rule
 | Crossplane v1 Best Practices | `rules/crossplane-v1-best-practices.md` | Crossplane/Upbound guidelines: XR design, compositions, managed resources | [View](rules/crossplane-v1-best-practices.md) |
 | Crossplane v2 Best Practices | `rules/crossplane-v2-best-practices.md` | Crossplane v2 specifics: namespaced XRs, spec.crossplane, Configuration packages | [View](rules/crossplane-v2-best-practices.md) |
 | Kubernetes Best Practices | `rules/kubernetes-best-practices.md` | Kubernetes guidelines: resource management, security, RBAC, networking | [View](rules/kubernetes-best-practices.md) |
-| Agent Delegation | `rules/agent-delegation.md` | Multi-agent delegation matrix with `UserPromptSubmit` hook to force consultation before bulk tasks | [View](rules/agent-delegation.md) |
+| Agent Delegation | `rules/agent-delegation.md` | Delegation matrix routing to real spawnable harness agents (Explore, cavecrew-*, general-purpose, Plan, codex:codex-rescue, Agent+model overrides), with a `UserPromptSubmit` hook to force consultation before bulk tasks | [View](rules/agent-delegation.md) |
 
 ## How Rules Work
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -12,7 +12,7 @@ For Claude Code skills (SKILL.md bundles), see [SKILLS.md](SKILLS.md).
 | Benchmark | Measure whether a skill produces better output than a baseline or previous version; issue a scored promotion verdict | [View](scripts/benchmark/README.md) |
 | Agent Delegation | Install the `agent-delegation` rule and its `UserPromptSubmit` hook into a target Claude Code project | [View](scripts/agent-delegation/README.md) |
 | Defensive Protocol v2 | Install the Defensive Protocol v2 rules (anti-slop/epistemology/session-management trio + over-engineering gate) plus the hooks that enforce them (chmod hard-block, destructive-command gate, overwrite reminder, failure reminder, over-engineering pre-build reminder) into a target project | [View](scripts/defensive-protocol/README.md) |
-| Claude Toolkit | Install battle-tested Claude Code helper scripts (file-based `gcommit`, hardened Codex review wrapper, branch-sync, quiet runner, state digest, self-test) plus two tool hooks (heredoc-commit block, markdown auto-fix) into a target project | [View](scripts/claude-toolkit/REFERENCE.md) |
+| Claude Toolkit | Install the gated project skill suite (flattened for discovery) plus battle-tested helper scripts (file-based `gcommit`, hardened Codex review wrapper, branch-sync, quiet runner, state digest, self-test) and two tool hooks (heredoc-commit block, markdown auto-fix) into a target project | [View](scripts/claude-toolkit/REFERENCE.md) |
 
 ## How Scripts Work
 
@@ -121,6 +121,8 @@ Requires `jq` (installer + hooks) and, for the test suite, `bats-core`. Verify a
 
 Installs battle-tested Claude Code session helpers — extracted from a production GitOps repository after weeks of live use — into a target project: a file-based commit helper that can never break on quoting, a hardened Codex review wrapper with machine-readable verdicts, post-squash-merge branch syncing, quiet command execution, a gated-workflow state digest, and a self-test harness. Two node hooks make the commit and markdown hygiene deterministic.
 
+It also installs the **gated project skill suite** (`/project`, `/build`, `/define`, `/design`, `/milestone`, `/plan-feature`, `/spike`), flattening the library's authoring nesting into the layout Claude Code can actually discover. The suite and the scripts ship together because `/build` invokes `gcommit` by path. Use `--no-skills` for scripts and hooks only.
+
 **Scripts:** `install.sh`, `gcommit`, `branch-sync.sh`, `codex-review.sh`, `run-quiet.sh`, `state-status.sh`, `check.sh`
 **Documentation:** [scripts/claude-toolkit/REFERENCE.md](scripts/claude-toolkit/REFERENCE.md) · bundle entry point: `scripts/claude-toolkit/README.md`
 
@@ -130,6 +132,7 @@ Installs battle-tested Claude Code session helpers — extracted from a producti
 |------|--------|
 | `<target>/.claude/scripts/*` | Six scripts copied (added \| updated \| unchanged) |
 | `<target>/.claude/hooks/*.js` | Two node hooks copied |
+| `<target>/.claude/skills/{project,build,define,design,milestone,plan-feature,spike}/` | Gated project suite, **flattened** from the library's `skills/project/<sub>/` nesting so each is discoverable one level deep. Overlay copy — consumer-added files survive, nothing is deleted. Skip with `--no-skills` |
 | `<target>/.claude/settings.json` | Two hook entries merged (versioned markers, timeout + statusMessage); existing keys preserved; pre-existing **unmarked** entries invoking the same hook scripts are migrated, not duplicated |
 | `<target>/CLAUDE.md` | `CLAUDE-TOOLKIT` sentinel block appended (Git/commit + review guidance); created if missing; malformed sentinel pairs fail the install |
 | `<target>/.cc-base-branch` | Only with `--base-branch NAME`, only if absent — never overwritten |

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -12,6 +12,7 @@ For Claude Code skills (SKILL.md bundles), see [SKILLS.md](SKILLS.md).
 | Benchmark | Measure whether a skill produces better output than a baseline or previous version; issue a scored promotion verdict | [View](scripts/benchmark/README.md) |
 | Agent Delegation | Install the `agent-delegation` rule and its `UserPromptSubmit` hook into a target Claude Code project | [View](scripts/agent-delegation/README.md) |
 | Defensive Protocol v2 | Install the Defensive Protocol v2 rules (anti-slop/epistemology/session-management trio + over-engineering gate) plus the hooks that enforce them (chmod hard-block, destructive-command gate, overwrite reminder, failure reminder, over-engineering pre-build reminder) into a target project | [View](scripts/defensive-protocol/README.md) |
+| Claude Toolkit | Install battle-tested Claude Code helper scripts (file-based `gcommit`, hardened Codex review wrapper, branch-sync, quiet runner, state digest, self-test) plus two tool hooks (heredoc-commit block, markdown auto-fix) into a target project | [View](scripts/claude-toolkit/REFERENCE.md) |
 
 ## How Scripts Work
 
@@ -115,3 +116,31 @@ Installs the Defensive Protocol v2 rules (`rules/defensive-protocol-v2-{anti-slo
 The installer is idempotent — re-running produces an empty diff (verified by `tests/installer.bats` and `tests/installer-over-engineering.bats`). Hook merges are keyed off versioned markers (`# dp2-chmod-block v1`, etc.); the CLAUDE.md block is keyed off the `<!-- BEGIN DEFENSIVE-PROTOCOL-V2 -->` sentinel. Bump a marker suffix (`v1` → `v2`) in `install.sh` to force re-installation.
 
 Requires `jq` (installer + hooks) and, for the test suite, `bats-core`. Verify an install with `bash scripts/defensive-protocol/test.sh`.
+
+## Claude Toolkit
+
+Installs battle-tested Claude Code session helpers — extracted from a production GitOps repository after weeks of live use — into a target project: a file-based commit helper that can never break on quoting, a hardened Codex review wrapper with machine-readable verdicts, post-squash-merge branch syncing, quiet command execution, a gated-workflow state digest, and a self-test harness. Two node hooks make the commit and markdown hygiene deterministic.
+
+**Scripts:** `install.sh`, `gcommit`, `branch-sync.sh`, `codex-review.sh`, `run-quiet.sh`, `state-status.sh`, `check.sh`
+**Documentation:** [scripts/claude-toolkit/REFERENCE.md](scripts/claude-toolkit/REFERENCE.md) · bundle entry point: `scripts/claude-toolkit/README.md`
+
+### Effects on the Target Repository
+
+| Path | Result |
+|------|--------|
+| `<target>/.claude/scripts/*` | Six scripts copied (added \| updated \| unchanged) |
+| `<target>/.claude/hooks/*.js` | Two node hooks copied |
+| `<target>/.claude/settings.json` | Two hook entries merged (versioned markers, timeout + statusMessage); existing keys preserved; pre-existing **unmarked** entries invoking the same hook scripts are migrated, not duplicated |
+| `<target>/CLAUDE.md` | `CLAUDE-TOOLKIT` sentinel block appended (Git/commit + review guidance); created if missing; malformed sentinel pairs fail the install |
+| `<target>/.cc-base-branch` | Only with `--base-branch NAME`, only if absent — never overwritten |
+
+### Hooks Installed
+
+| Hook | Event / Matcher | Behavior |
+|------|-----------------|----------|
+| `block-heredoc-commit.js` | `PreToolUse` / `Bash` | Denies `git commit` using a heredoc or multi-line `-m`; steers to `gcommit` / `git commit -F` |
+| `lint-md-on-edit.js` | `PostToolUse` / `Edit\|Write` | Auto-fixes edited `.md` files via `markdownlint-cli2` (silent no-op when the binary is absent) |
+
+The installer is idempotent — re-running produces an empty diff (verified by `tests/installer-claude-toolkit.bats`). Hook merges are keyed off versioned markers (`# cc-toolkit-heredoc-block v1`, `# cc-toolkit-lint-md v1`); the CLAUDE.md block is keyed off the `<!-- BEGIN CLAUDE-TOOLKIT -->` sentinel.
+
+Requires `jq` and `node` (hard); `markdownlint-cli2`, `codex` CLI, and GNU `timeout` are optional runtime dependencies (warn-only). Self-test with `bash scripts/claude-toolkit/check.sh`.

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -20,6 +20,7 @@ For single-file commands (no supporting assets), see [COMMANDS.md](COMMANDS.md).
 | Plan Feature | `/plan-feature` | Per-feature implementation plan with sub-feature sizing and test commands (Gate 4) | [View](skills/plan-feature.md) |
 | Build | `/build` | Sub-feature implementation from Gate 4-approved plans with test gating and deviation tracking | [View](skills/build.md) |
 | Spike | `/spike` | Adversarial technical research with red-team validation and follow-up support | [View](skills/spike.md) |
+| Red-Team | `/red-team` | Adversarial review of any artifact — spawns parallel sub-agents with different adversarial lenses | [View](skills/red-team.md) |
 | OCC Skill Creator | `/occ-skill-creator` | Guide for creating new skills that extend Claude's capabilities | [View](skills/occ-skill-creator.md) |
 | OCC Skill Refactor | `/occ-skill-refactor` | Reviews and refactors an existing skill against quality standards and best practices | [View](skills/occ-skill-refactor.md) |
 | Project Codex Skills | `$project` | Codex project suite -- bootstraps state, reports status, routes to the next explicit `$project-*` skill | [View](skills/project.md) |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -64,27 +64,60 @@ license: Apache-2.0                 # Optional. License identifier.
 
 ## Consuming Skills
 
+Skills are copied, not installed — there is **no installer for skills**. (The only installers in this
+repository are `scripts/agent-delegation/install.sh`, `scripts/defensive-protocol/install.sh`, and
+`scripts/claude-toolkit/install.sh`; each installs its own rules/scripts/hooks and wires
+`settings.json`. None of them copy skills.)
+
 Copy the entire skill directory from `skills/` into `.claude/skills/` in the target repository:
 
 ```bash
-# Copy a skill bundle
-cp -r skills/cdk-testing/       <target-repo>/.claude/skills/cdk-testing/
-cp -r skills/terraform-testing/  <target-repo>/.claude/skills/terraform-testing/
+# Standalone skills — one directory each
+cp -r skills/architecture-doc/          <target-repo>/.claude/skills/architecture-doc/
+cp -r skills/cdk-testing/               <target-repo>/.claude/skills/cdk-testing/
+cp -r skills/terraform-testing/         <target-repo>/.claude/skills/terraform-testing/
 cp -r skills/itsg-assessment/           <target-repo>/.claude/skills/itsg-assessment/
 cp -r skills/nist-fedramp-assessment/   <target-repo>/.claude/skills/nist-fedramp-assessment/
 cp -r skills/nist-csf-assessment/       <target-repo>/.claude/skills/nist-csf-assessment/
 cp -r skills/create-prd/                <target-repo>/.claude/skills/create-prd/
-cp -r skills/project/milestone/          <target-repo>/.claude/skills/project/milestone/
-cp -r skills/project/plan-feature/        <target-repo>/.claude/skills/project/plan-feature/
-cp -r skills/project/spike/               <target-repo>/.claude/skills/project/spike/
-cp -r skills/project/define/              <target-repo>/.claude/skills/project/define/
-cp -r skills/project/design/              <target-repo>/.claude/skills/project/design/
-cp -r skills/project/build/               <target-repo>/.claude/skills/project/build/
+cp -r skills/red-team/                  <target-repo>/.claude/skills/red-team/
 cp -r skills/occ-skill-creator/         <target-repo>/.claude/skills/occ-skill-creator/
 cp -r skills/occ-skill-refactor/        <target-repo>/.claude/skills/occ-skill-refactor/
-cp -r skills/project/                   <target-repo>/.claude/skills/project/
 cp -r skills/rule-creator/              <target-repo>/.claude/skills/rule-creator/
 cp -r skills/over-engineering-review/   <target-repo>/.claude/skills/over-engineering-review/
+
+# Gated project suite — the orchestrator plus its nested sub-skills.
+# One copy takes the whole suite (build, define, design, milestone, plan-feature, spike):
+cp -r skills/project/                   <target-repo>/.claude/skills/project/
+
+# ...or cherry-pick sub-skills (skills/project/SKILL.md is required either way):
+cp -r skills/project/build/             <target-repo>/.claude/skills/project/build/
+cp -r skills/project/define/            <target-repo>/.claude/skills/project/define/
+cp -r skills/project/design/            <target-repo>/.claude/skills/project/design/
+cp -r skills/project/milestone/         <target-repo>/.claude/skills/project/milestone/
+cp -r skills/project/plan-feature/      <target-repo>/.claude/skills/project/plan-feature/
+cp -r skills/project/spike/             <target-repo>/.claude/skills/project/spike/
 ```
 
 Skills take effect immediately on the next Claude Code conversation in that repository.
+
+### Prerequisite: the Claude Toolkit scripts
+
+`/build` and `/start-feature-auto` invoke helper scripts by path. Copying the skill alone leaves
+those instructions pointing at files that do not exist:
+
+| Consumer | Requires | Why |
+|---|---|---|
+| `skills/project/build/` (`/build`) | `.claude/scripts/gcommit` | Commit Command Protocol D-03 — every sub-feature and assessment-refresh commit is file-based |
+| `commands/start-feature-auto.md` | `.claude/scripts/codex-review.sh` | Step 7 Codex review before the feature closes |
+
+Install them first — this is the one install script involved in setting up the project suite, and it
+installs **scripts and hooks only, never skills**:
+
+```bash
+bash scripts/claude-toolkit/install.sh <target-repo-path>
+```
+
+See [SCRIPTS.md](SCRIPTS.md#claude-toolkit) for what it writes to the target. Without it, `/build`
+still runs but its commit step fails on a missing `gcommit`; `/start-feature-auto` records the review
+as skipped rather than blocking.

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -64,12 +64,16 @@ license: Apache-2.0                 # Optional. License identifier.
 
 ## Consuming Skills
 
-Skills are copied, not installed — there is **no installer for skills**. (The only installers in this
-repository are `scripts/agent-delegation/install.sh`, `scripts/defensive-protocol/install.sh`, and
-`scripts/claude-toolkit/install.sh`; each installs its own rules/scripts/hooks and wires
-`settings.json`. None of them copy skills.)
+Most skills are copied by hand. The one exception is the **gated project suite**, which
+`scripts/claude-toolkit/install.sh` installs for you — along with the helper scripts it depends on
+and the correct flattened layout:
 
-Copy the entire skill directory from `skills/` into `.claude/skills/` in the target repository:
+```bash
+bash scripts/claude-toolkit/install.sh <target-repo-path>   # project suite + scripts + hooks
+bash scripts/claude-toolkit/install.sh --no-skills <target> # scripts + hooks only
+```
+
+Everything else is a directory copy from `skills/` into `.claude/skills/` in the target repository:
 
 ```bash
 # Standalone skills — one directory each
@@ -86,17 +90,39 @@ cp -r skills/occ-skill-refactor/        <target-repo>/.claude/skills/occ-skill-r
 cp -r skills/rule-creator/              <target-repo>/.claude/skills/rule-creator/
 cp -r skills/over-engineering-review/   <target-repo>/.claude/skills/over-engineering-review/
 
-# Gated project suite — the orchestrator plus its nested sub-skills.
-# One copy takes the whole suite (build, define, design, milestone, plan-feature, spike):
-cp -r skills/project/                   <target-repo>/.claude/skills/project/
+# Gated project suite — MUST be flattened; see "Flatten the project suite" below.
+# Prefer the installer, which does this for you.
+cp -r skills/project/build/             <target-repo>/.claude/skills/build/
+cp -r skills/project/define/            <target-repo>/.claude/skills/define/
+cp -r skills/project/design/            <target-repo>/.claude/skills/design/
+cp -r skills/project/milestone/         <target-repo>/.claude/skills/milestone/
+cp -r skills/project/plan-feature/      <target-repo>/.claude/skills/plan-feature/
+cp -r skills/project/spike/             <target-repo>/.claude/skills/spike/
+# ...then the orchestrator itself, WITHOUT re-copying the sub-skill dirs above:
+mkdir -p                                <target-repo>/.claude/skills/project/
+cp    skills/project/SKILL.md           <target-repo>/.claude/skills/project/
+cp -r skills/project/references/        <target-repo>/.claude/skills/project/references/
+```
 
-# ...or cherry-pick sub-skills (skills/project/SKILL.md is required either way):
-cp -r skills/project/build/             <target-repo>/.claude/skills/project/build/
-cp -r skills/project/define/            <target-repo>/.claude/skills/project/define/
-cp -r skills/project/design/            <target-repo>/.claude/skills/project/design/
-cp -r skills/project/milestone/         <target-repo>/.claude/skills/project/milestone/
-cp -r skills/project/plan-feature/      <target-repo>/.claude/skills/project/plan-feature/
-cp -r skills/project/spike/             <target-repo>/.claude/skills/project/spike/
+### Flatten the project suite
+
+This library nests the gated suite as `skills/project/<sub>/` for authoring, but that is **not** a
+valid installed layout. Claude Code scans `.claude/skills/` exactly one level deep, and a skill's
+slash command comes from its **directory name** — for project and personal skills the `name:`
+frontmatter only sets the display label shown in listings.
+
+| Installed path | Result |
+|---|---|
+| `.claude/skills/build/SKILL.md` | Discovered as `/build` |
+| `.claude/skills/project/build/SKILL.md` | Never discovered — one level too deep |
+
+Copying `skills/project/` wholesale into `.claude/skills/project/` therefore yields a `/project`
+orchestrator whose six sub-skills are all invisible — and `/project` routes to them by bare name
+(`/build`, `/define`, ...), so the workflow dead-ends at the first gate. Flatten the suite, as shown
+above, or let the installer do it:
+
+```bash
+bash scripts/claude-toolkit/install.sh <target-repo-path>
 ```
 
 Skills take effect immediately on the next Claude Code conversation in that repository.
@@ -111,13 +137,10 @@ those instructions pointing at files that do not exist:
 | `skills/project/build/` (`/build`) | `.claude/scripts/gcommit` | Commit Command Protocol D-03 — every sub-feature and assessment-refresh commit is file-based |
 | `commands/start-feature-auto.md` | `.claude/scripts/codex-review.sh` | Step 7 Codex review before the feature closes |
 
-Install them first — this is the one install script involved in setting up the project suite, and it
-installs **scripts and hooks only, never skills**:
+A default `bash scripts/claude-toolkit/install.sh <target-repo-path>` installs both the suite and
+these scripts together, so the dependency is satisfied automatically. It matters when the pieces are
+installed separately — a hand-copied suite, or an install run with `--no-skills`. Without the
+scripts, `/build` still runs but its commit step fails on a missing `gcommit`, and
+`/start-feature-auto` records the review as skipped rather than blocking.
 
-```bash
-bash scripts/claude-toolkit/install.sh <target-repo-path>
-```
-
-See [SCRIPTS.md](SCRIPTS.md#claude-toolkit) for what it writes to the target. Without it, `/build`
-still runs but its commit step fails on a missing `gcommit`; `/start-feature-auto` records the review
-as skipped rather than blocking.
+See [SCRIPTS.md](SCRIPTS.md#claude-toolkit) for everything the installer writes to the target.

--- a/docs/commands/investigate.md
+++ b/docs/commands/investigate.md
@@ -30,7 +30,7 @@ Can be invoked with or without a description. If no description is provided, the
 
 | Output | Location | Description |
 |---|---|---|
-| Investigation file | `agents/investigations/[slug].md` | Structured document with facts, theories, tests performed, and resolution |
+| Investigation file | `agents/investigations/[slug]/[slug].md` | Structured document with facts, theories, tests performed, and resolution |
 | Resolution report | Console (stdout) | Summary of root cause, fix applied, and prevention strategy |
 
 ## Workflow
@@ -47,7 +47,7 @@ Creates a slug from the topic (e.g., `circular-dependency`, `aurora-connection-t
 
 ### Step 2 — Create investigation file
 
-Writes `agents/investigations/[slug].md` with this structure:
+Writes `agents/investigations/[slug]/[slug].md` with this structure:
 
 ```markdown
 # Investigation: [Title]
@@ -103,14 +103,16 @@ Works through the theories systematically:
 3. **Record every test** in the Tests Performed table — even negative results are valuable data.
 4. **Update Facts and Theories** as learning progresses — promotes confirmed theories to facts, eliminates disproven ones.
 5. **Maintain 3+ hypotheses** — if down to one unconfirmed theory, generates more alternatives.
+6. **Codex review of the hypotheses** — once 3+ competing hypotheses are recorded and before running the tests, hands the investigation file (plus the implicated source files) to Codex for an independent read. Codex is asked for non-distinct hypotheses, hypotheses contradicted by the recorded Facts, missing hypotheses the evidence supports, and tests that cannot discriminate between theories. Valid findings are folded back into Facts/Theories before testing; rejected findings get a one-line reason. Skipped entirely when codex is unavailable.
 
 ### Step 4 — Resolve
 
 When the root cause is found:
 
 1. Fills in the Resolution section with root cause, fix applied, and prevention strategy.
-2. Changes Status from `Active` to `Resolved`.
-3. Reports to the user:
+2. **Codex review of the resolution** — hands the completed investigation file to Codex to verify the root cause is supported by the recorded Facts and Tests (not asserted), the fix addresses the root cause rather than the symptom, no competing hypothesis was left un-eliminated, and Prevention is concrete. Valid findings are addressed before closing; an unsupported root cause keeps the investigation `Active` and returns to Step 3. Skipped entirely when codex is unavailable.
+3. Changes Status from `Active` to `Resolved`.
+4. Reports to the user:
 
 ```
 INVESTIGATION RESOLVED: [title]
@@ -118,11 +120,21 @@ INVESTIGATION RESOLVED: [title]
 Root cause: [one sentence]
 Fix: [what was changed]
 Prevention: [how to avoid in future]
+Codex review: [X valid / Y rejected — or "skipped (codex unavailable)"]
 
-Full investigation: agents/investigations/[slug].md
+Full investigation: agents/investigations/[slug]/[slug].md
 ```
 
 If the investigation represents a permanent learning (likely to recur, non-obvious), suggests adding it to CLAUDE.md via the `/memory` command.
+
+### Codex Review
+
+Both review points share one mechanism, documented in the command under `## Codex Review`:
+
+- **Availability guard** — `command -v codex`. If codex or `.claude/scripts/codex-review.sh` is missing, the review is skipped and the investigation continues; the skip is recorded in the file and the report. Review tooling is never a gate.
+- **Invocation** — `bash .claude/scripts/codex-review.sh <investigation file> [source files...] -p "<review questions>"`. The hardened wrapper is used instead of a hand-rolled `codex exec` (closed stdin, timeout, `-s read-only` sandbox). Exit `0` = PASS, `1` = FAIL, `2` = review failed (treated as "no verdict", never as PASS).
+- **Alternative** — the `codex:codex-rescue` agent when the `codex` plugin is installed.
+- **Triage** — every finding is classified VALID (reproducible against the recorded Facts/Tests or the real source) or REJECTED (one-line reason). Codex output is never auto-applied to the investigation file.
 
 ## When to Use
 

--- a/docs/commands/start-feature-auto.md
+++ b/docs/commands/start-feature-auto.md
@@ -102,6 +102,11 @@ parallel, then merges results.
 
 ### Step 7 — Codex review of the completed change set
 
+> **Requires** `.claude/scripts/codex-review.sh` from the Claude Toolkit bundle
+> (`bash scripts/claude-toolkit/install.sh <target-repo-path>`) plus the `codex` CLI. When either is
+> absent the step records `CODEX REVIEW: skipped (codex unavailable — <reason>)` and the feature
+> still closes.
+
 After implementation finishes and local tests/linters pass, reviews the work with Codex before
 closing: assembles the change set and acceptance criteria, writes a review brief, runs the
 hardened wrapper (`bash .claude/scripts/codex-review.sh --diff` — never a hand-rolled

--- a/docs/commands/start-feature-auto.md
+++ b/docs/commands/start-feature-auto.md
@@ -100,10 +100,27 @@ Executes using the recorded model. Inline proceeds directly. Sub-agent launches 
 agent in a worktree with the full feature context. Team launches one agent per work stream in
 parallel, then merges results.
 
-### Step 7 — Close the feature
+### Step 7 — Codex review of the completed change set
 
-Appends `CODE COMPLETE` and `Completed YYYY-MM-DD` to NOTES, changes status to `[x]`, and
-reports to the user with execution model, files changed, and the next feature.
+After implementation finishes and local tests/linters pass, reviews the work with Codex before
+closing: assembles the change set and acceptance criteria, writes a review brief, runs the
+hardened wrapper (`bash .claude/scripts/codex-review.sh --diff` — never a hand-rolled
+`codex exec`; exit 0 = PASS, 1 = FAIL, 2 = no verdict and never inferred as PASS), then triages
+every finding as VALID (confirmed against the code) or REJECTED (with a one-line reason).
+Codex unavailability is non-fatal — recorded and reported, never blocking.
+
+### Step 8 — Refactor on valid findings (conditional)
+
+Clean review (or only REJECTED findings) skips straight to close. Valid findings are addressed
+using the same execution model recorded in NOTES, staying within feature scope, HIGH before LOW;
+tests and linters re-run, with at most one confirming Codex re-review. An unresolved valid HIGH
+finding leaves the feature `[~]` and reports instead of closing.
+
+### Step 9 — Close the feature
+
+Appends `CODE COMPLETE`, `CODEX REVIEW`, `REFACTOR`, and `Completed YYYY-MM-DD` to NOTES,
+changes status to `[x]`, and reports to the user with execution model, files changed, review
+outcome, and the next feature.
 
 ## NOTES Structure
 
@@ -117,8 +134,10 @@ The NOTES block has a consistent structure written in two passes:
 | `KEY DECISIONS` | Step 4 — before implementation | Relevant design decisions |
 | `DEPENDENCIES` | Step 4 — before implementation | Feature and external deps |
 | `EXECUTION` | Step 5 — before implementation | Chosen model and rationale |
-| `CODE COMPLETE` | Step 7 — after implementation | Files changed, test and lint status |
-| `Completed` | Step 7 — after implementation | Completion date |
+| `CODE COMPLETE` | Step 9 — after implementation | Files changed, test and lint status |
+| `CODEX REVIEW` | Step 9 — after review | Finding counts (H/M/L), valid vs rejected with reasons |
+| `REFACTOR` | Step 9 — after refactor | What changed to resolve valid findings, or "none (review clean)" |
+| `Completed` | Step 9 — after implementation | Completion date |
 
 ## Error Handling
 

--- a/docs/rules/agent-delegation.md
+++ b/docs/rules/agent-delegation.md
@@ -10,7 +10,9 @@ State the delegation decision before the first tool call on any bulk task. The m
 
 ## Overview
 
-This rule defines which sub-agent should handle which class of work. The delegation matrix covers six agents — Sonnet (coordinator), Haiku (cheap localized work), Opus (deep reasoning), Codex (terminal/scripting), Gemini (long-context discovery), and Explore (in-session bulk reads) — with explicit trigger phrases, escalation logic, and avoidance criteria.
+This rule defines which sub-agent should handle which class of work. The delegation matrix routes to **real spawnable agents** in the Claude Code harness (the `Agent` tool's `subagent_type`, plus `model` overrides) — the main thread (coordinator), `Explore` (bulk read-only discovery), `cavecrew-investigator` (compressed code location), `general-purpose` (multi-step search/research), `Plan` (architecture), `cavecrew-builder` (surgical 1–2 file edits), `cavecrew-reviewer` (diff review), `codex:codex-rescue` (terminal/second-opinion), and `Agent + model: haiku/opus` for cost/depth tuning — with explicit trigger phrases, escalation logic, and avoidance criteria. Model names (Sonnet/Haiku/Opus/Gemini) are **not** spawnable agent types; the rule routes to agents and uses `model` overrides for tuning.
+
+**Plugin availability:** `cavecrew-*` agents come from the `caveman` plugin and `codex:codex-rescue` from the `codex` plugin. The rule includes fallback routing to built-ins (`Explore`, `general-purpose`, `Agent + model`) for harnesses without those plugins.
 
 The rule ships with a companion `UserPromptSubmit` hook because field testing showed that loading the matrix into context is not enough. Without a forcing function, the agent reads the rule but routes around it: by the time a bulk task arrives, "act now" beats "consult the matrix" on every iteration. The hook injects a one-line reminder when the user's prompt matches bulk-work keywords, raising the trigger card to the agent's attention at the moment it is about to pick its first tool.
 
@@ -20,7 +22,7 @@ Adopt this rule on any project where Claude Code is the primary development agen
 
 ### Trigger Card
 
-A six-line fast-path table at the top of the rule. Maps task shape to agent: bulk discovery → Explore, log retrieval / output parsing → Haiku, repo-wide search → Gemini, architecture/blocker → Opus, terminal/scripting → Codex, default → Sonnet. Designed to drop consultation cost from "re-read the matrix" to "scan five lines."
+A fast-path table at the top of the rule. Maps task shape to agent: bulk discovery → Explore, locate code → cavecrew-investigator, multi-step search → general-purpose, architecture/planning → Plan, surgical 1–2 file edit → cavecrew-builder, diff review → cavecrew-reviewer, terminal/second-opinion → codex:codex-rescue, cheap localized task → Agent + model: haiku, deep reasoning → Agent + model: opus, default → main thread. Designed to drop consultation cost from "re-read the matrix" to "scan a few lines."
 
 ### Entry Condition
 
@@ -30,20 +32,26 @@ A single forcing sentence: "Before starting any task with more than five read-on
 
 Establishes that delegation is a deliberate optimization for context efficiency, iteration speed, token cost, specialization, and reduced cognitive fragmentation — not a way to offload responsibility. The coordinating agent retains architectural ownership even when subtasks are delegated.
 
-### Primary Coordinator (Sonnet)
+### Primary Coordinator (main thread)
 
-Sonnet is the default development and orchestration agent. Responsibilities: multi-step coordination, architectural consistency, `CLAUDE.md` enforcement, integration of delegated outputs, correctness validation, and nuanced refactoring. Even when delegation occurs, Sonnet remains responsible for final integration, consistency validation, project-wide reasoning, and implementation cohesion.
+The main thread is the default development and orchestration agent. Responsibilities: multi-step coordination, architectural consistency, `CLAUDE.md` enforcement, integration of delegated outputs, correctness validation, and nuanced refactoring. Even when delegation occurs, the main thread remains responsible for final integration, consistency validation, project-wide reasoning, and implementation cohesion.
 
 ### Delegation Matrix
 
-Six rows. Each lists the agent, when to delegate to it, its strengths, and its weaknesses:
+Ten rows. Each lists the agent, when to delegate to it, its strengths, and its weaknesses:
 
-- **Sonnet** — default for feature development, refactoring, debugging, coordinated multi-file changes. Best balance of reasoning, context retention, architectural cohesion. Less cost-efficient for repetitive boilerplate.
-- **Haiku** — tests, documentation, schema mappings, repetitive CRUD, simple UI/CSS, log retrieval and output parsing. Fast and cheap for localized tasks. Weak at deep architectural reasoning.
-- **Opus** — unresolved system failures, security design, difficult debugging, core architecture decisions. Maximum reasoning depth. Highest latency and cost.
-- **Codex** — terminal workflows, shell scripts, deterministic implementation, regex transformations, tooling glue. Strong execution accuracy. Smaller effective context, weaker project-wide cohesion.
-- **Gemini** — repository-wide discovery, large log analysis, legacy codebase scanning, long-document ingestion. Massive context window. Lower implementation precision; outputs require validation.
-- **Explore** — bulk read-only discovery, multi-file enumeration, "where is X defined" questions, initial codebase reconnaissance. Built-in Claude Code subagent; preserves the main context window. Read-only; reads excerpts, not whole files; misses content past its read window.
+- **main thread (me)** — default for feature development, refactoring, debugging, coordinated multi-file changes. Holds architectural context. Consumes the primary context window on bulk work.
+- **Explore** — bulk read-only discovery, multi-file enumeration, "where is X defined" questions, initial codebase reconnaissance. Built-in subagent; preserves the main context window. Read-only; reads excerpts, not whole files.
+- **cavecrew-investigator** — locate code ("where is X defined", "what calls Y", map a directory). Read-only locator with compressed output (~60% fewer tokens back to the main thread). Refuses to suggest fixes.
+- **general-purpose** — multi-step search/research, open-ended discovery, repo-wide dependency tracing. Full toolset; heavier than Explore; validate output before merge.
+- **Plan** — architecture decisions and implementation-strategy design. Returns step-by-step plans and critical files. Read-only, planning only.
+- **cavecrew-builder** — surgical 1–2 file edits: typo fixes, single-function rewrites, mechanical renames. Hard-refuses 3+ file scope.
+- **cavecrew-reviewer** — diff / branch / file review with severity-tagged one-line findings. Review only.
+- **codex:codex-rescue** — terminal/scripting workflows, second implementation or diagnosis pass, deep root-cause. Independent engine; validate before merge.
+- **Agent + `model: haiku`** — cheap localized tasks: tests, docs, schema mappings, repetitive CRUD, log parsing. Weak at deep architectural reasoning.
+- **Agent + `model: opus`** — unresolved failures, security design, hard debugging, core architecture. Maximum reasoning depth; highest latency and cost.
+
+A plugin-availability paragraph follows the matrix with fallback routing (`cavecrew-investigator` → `Explore`, `cavecrew-builder` → `Agent + model: haiku`, `cavecrew-reviewer` / `codex:codex-rescue` → `general-purpose`) for harnesses without the `caveman` / `codex` plugins.
 
 ### Delegation Requirements
 
@@ -55,19 +63,19 @@ Five mandatory checks on delegated outputs: architectural consistency review, pr
 
 ### Parallel Delegation
 
-When beneficial, fan out to multiple agents simultaneously: Explore for in-session reads, Gemini for cross-repository discovery, Haiku for tests/docs, Codex for scripts/tooling, Sonnet for orchestration, Opus for escalation. Parallel delegation should improve throughput without fragmenting architectural ownership.
+When beneficial, fan out to multiple agents simultaneously: Explore/cavecrew-investigator for in-session reads and code-locate, general-purpose for repo-wide discovery, Agent + `model: haiku` for tests/docs, codex:codex-rescue for scripts/tooling, the main thread for orchestration, Agent + `model: opus` for escalation. Parallel delegation should improve throughput without fragmenting architectural ownership.
 
 ### Trigger Phrase Routing
 
-A 12-row table mapping common user phrasings to target agents. Examples: "Generate exhaustive unit tests for…" → Haiku. "Find where X is defined…" → Explore. "Scan the repository for…" → Gemini. "Design the architecture for…" → Opus. "Refactor this subsystem safely…" → Sonnet. "Write a shell script to…" → Codex. The table is the matrix's "by example" companion.
+A 14-row table mapping common user phrasings to target agents. Examples: "Generate exhaustive unit tests for…" → Agent + `model: haiku`. "Find where X is defined…" → cavecrew-investigator. "Scan the repository for…" → general-purpose. "Review this diff / PR…" → cavecrew-reviewer. "Design the architecture for…" → Plan. "Refactor this subsystem safely…" → main thread. "Write a shell script to…" → codex:codex-rescue. The table is the matrix's "by example" companion.
 
 ### Escalation Logic
 
-Six-step ordering: start with Sonnet → use Explore for bulk reads → delegate localized work to Haiku → use Gemini for repo-wide work → use Codex for execution-heavy workflows → escalate to Opus when blocked, when architectural uncertainty persists, when debugging becomes non-deterministic, or when security/systems reasoning becomes critical. Escalation is intentional, not automatic.
+Six-step ordering: start on the main thread → use Explore/cavecrew-investigator for bulk reads and code-locate → delegate localized work to Agent + `model: haiku` → use general-purpose for repo-wide or multi-step discovery → use codex:codex-rescue for execution-heavy or second-opinion workflows → escalate to Agent + `model: opus` when blocked, when architectural uncertainty persists, when debugging becomes non-deterministic, or when security/systems reasoning becomes critical. Escalation is intentional, not automatic.
 
 ### Repository Discovery Guidance
 
-Splits in-session vs. long-context discovery. **Explore** for searching the current repository, enumerating files, locating definitions, and preserving the main context window. **Gemini** for legacy or massive repositories, dependency chains across millions of lines, log analysis, long-document ingestion. Both are discovery tools; implementation derived from their analysis must be validated by Sonnet or Opus before merge.
+Splits fast in-session vs. open-ended multi-step discovery. **Explore** (or **cavecrew-investigator** for compressed locate-only output) for searching the current repository, enumerating files, locating definitions, and preserving the main context window. **general-purpose** for open-ended searches where first tries may miss, dependency chains across many files, and multi-step research needing the full toolset. Both are discovery agents; implementation derived from their analysis must be validated on the main thread before merge.
 
 ### Avoid Delegation When
 

--- a/docs/scripts/claude-toolkit/REFERENCE.md
+++ b/docs/scripts/claude-toolkit/REFERENCE.md
@@ -18,6 +18,10 @@ bash scripts/claude-toolkit/install.sh [--base-branch NAME] <target-repo-path>
 | `--base-branch NAME` | Writes `<target>/.cc-base-branch` only if the file is absent; a differing existing file is warned about and left unchanged |
 | Hard prerequisites | `jq`, `node` |
 | Warn-only | `markdownlint-cli2`, `codex` CLI |
+| Does **not** install | Skills, commands, or rules — those are copied with `cp -r` (see [SKILLS.md](../../SKILLS.md#consuming-skills), [COMMANDS.md](../../COMMANDS.md#consuming-commands)) |
+
+`/build` requires the installed `gcommit` and `/start-feature-auto` requires the installed
+`codex-review.sh`, so run this installer **before** copying those skills/commands into a target repo.
 
 ## gcommit
 

--- a/docs/scripts/claude-toolkit/REFERENCE.md
+++ b/docs/scripts/claude-toolkit/REFERENCE.md
@@ -7,21 +7,42 @@ All scripts are invoked with an explicit interpreter (`bash <script>`) — nothi
 ## install.sh
 
 ```bash
-bash scripts/claude-toolkit/install.sh [--base-branch NAME] <target-repo-path>
+bash scripts/claude-toolkit/install.sh [--base-branch NAME] [--no-skills] <target-repo-path>
 ```
 
 | Aspect | Detail |
 |---|---|
-| Copies | Six scripts → `<target>/.claude/scripts/`; two hooks → `<target>/.claude/hooks/` |
+| Copies | Six scripts → `<target>/.claude/scripts/`; two hooks → `<target>/.claude/hooks/`; the gated project suite → `<target>/.claude/skills/` (flattened, see below) |
+| `--no-skills` | Skip the skill suite; install scripts and hooks only |
 | settings.json | jq-merges two hook entries with versioned markers; migrates pre-existing unmarked entries invoking the same hook scripts |
 | CLAUDE.md | Appends the `<!-- BEGIN CLAUDE-TOOLKIT -->` sentinel block; hard-fails on a malformed (unpaired) sentinel |
 | `--base-branch NAME` | Writes `<target>/.cc-base-branch` only if the file is absent; a differing existing file is warned about and left unchanged |
 | Hard prerequisites | `jq`, `node` |
 | Warn-only | `markdownlint-cli2`, `codex` CLI |
-| Does **not** install | Skills, commands, or rules — those are copied with `cp -r` (see [SKILLS.md](../../SKILLS.md#consuming-skills), [COMMANDS.md](../../COMMANDS.md#consuming-commands)) |
+| Does **not** install | Commands or rules — copy those with `cp` (see [COMMANDS.md](../../COMMANDS.md#consuming-commands), [RULES.md](../../RULES.md)) |
 
-`/build` requires the installed `gcommit` and `/start-feature-auto` requires the installed
-`codex-review.sh`, so run this installer **before** copying those skills/commands into a target repo.
+### Skill layout (flattened)
+
+Claude Code scans `.claude/skills/` one level deep and derives each slash command from the
+**directory name**; for project skills the `name:` frontmatter only sets the display label. The
+library's authoring nesting is flattened on install:
+
+| Source | Installed | Command |
+|---|---|---|
+| `skills/project/SKILL.md` + `references/` | `.claude/skills/project/` | `/project` |
+| `skills/project/build/` | `.claude/skills/build/` | `/build` |
+| `skills/project/define/` | `.claude/skills/define/` | `/define` |
+| `skills/project/design/` | `.claude/skills/design/` | `/design` |
+| `skills/project/milestone/` | `.claude/skills/milestone/` | `/milestone` |
+| `skills/project/plan-feature/` | `.claude/skills/plan-feature/` | `/plan-feature` |
+| `skills/project/spike/` | `.claude/skills/spike/` | `/spike` |
+
+The orchestrator directory receives no copy of the sub-skills. Skill copies are an overlay —
+consumer-added files survive an upgrade and nothing is deleted, so a stale file from an older
+version is not pruned (remove the directory by hand for a clean reinstall).
+
+`/start-feature-auto` is a command, not a skill: copy it separately, and note it requires the
+installed `codex-review.sh`.
 
 ## gcommit
 

--- a/docs/scripts/claude-toolkit/REFERENCE.md
+++ b/docs/scripts/claude-toolkit/REFERENCE.md
@@ -1,0 +1,117 @@
+# Claude Toolkit — Reference
+
+Per-script reference for the `scripts/claude-toolkit/` bundle. For the quick start and install effects, see the bundle entry point at `scripts/claude-toolkit/README.md`; for the index of all script bundles, see [SCRIPTS.md](../../SCRIPTS.md).
+
+All scripts are invoked with an explicit interpreter (`bash <script>`) — nothing in this bundle is ever executable. Installed paths below assume the target repo root as working directory.
+
+## install.sh
+
+```bash
+bash scripts/claude-toolkit/install.sh [--base-branch NAME] <target-repo-path>
+```
+
+| Aspect | Detail |
+|---|---|
+| Copies | Six scripts → `<target>/.claude/scripts/`; two hooks → `<target>/.claude/hooks/` |
+| settings.json | jq-merges two hook entries with versioned markers; migrates pre-existing unmarked entries invoking the same hook scripts |
+| CLAUDE.md | Appends the `<!-- BEGIN CLAUDE-TOOLKIT -->` sentinel block; hard-fails on a malformed (unpaired) sentinel |
+| `--base-branch NAME` | Writes `<target>/.cc-base-branch` only if the file is absent; a differing existing file is warned about and left unchanged |
+| Hard prerequisites | `jq`, `node` |
+| Warn-only | `markdownlint-cli2`, `codex` CLI |
+
+## gcommit
+
+Commit via message file only — writes the message to `$GIT_DIR/CLAUDE_COMMIT_MSG` and runs `git commit -F`, so shell quoting can never break a commit.
+
+```bash
+bash .claude/scripts/gcommit "subject line"        # subject as argument
+bash .claude/scripts/gcommit path/to/message.txt   # argument that is a file = message file
+printf 'subject\n\nbody\n' | bash .claude/scripts/gcommit   # full message on stdin
+```
+
+Companion to the `block-heredoc-commit` hook, which denies heredoc / multi-line `-m` commits and steers here.
+
+## branch-sync.sh
+
+Resets a feature branch onto the integration base after a squash-merge (`git reset --hard origin/<base>`). Interactive `y/N` confirm; refuses a dirty working tree; refuses to run while checked out on the base branch.
+
+```bash
+bash .claude/scripts/branch-sync.sh [feature-branch]
+```
+
+Base-branch resolution order:
+
+1. `$CC_BASE_BRANCH` environment variable
+2. `.cc-base-branch` file at the repo top level (first line)
+3. The origin HEAD branch (`git remote show origin`)
+
+## codex-review.sh
+
+Hardened wrapper for Codex code review: closed stdin (an open stdin hangs `codex exec`), enforced timeout, `-s read-only` sandbox, and a machine-readable final `VERDICT: PASS` / `VERDICT: FAIL` line.
+
+```bash
+bash .claude/scripts/codex-review.sh --diff              # working diff + untracked files
+bash .claude/scripts/codex-review.sh --staged            # staged changes
+bash .claude/scripts/codex-review.sh --commits A..B      # commit range
+bash .claude/scripts/codex-review.sh FILE [FILE...]      # explicit files
+# optional: -p "extra prompt/acceptance criteria", -t <seconds> timeout
+```
+
+| Exit code | Meaning |
+|---|---|
+| 0 | `VERDICT: PASS` |
+| 1 | `VERDICT: FAIL` — findings to triage |
+| 2 | Review failed (timeout, codex error, no verdict) — **never treat as PASS** |
+
+Dependencies: `git`, `jq`, `codex` CLI, GNU `timeout`/`gtimeout` (macOS: `brew install coreutils`).
+
+## run-quiet.sh
+
+Runs any command, keeps the full log in `$TMPDIR`, and prints only a summary: `OK` + warnings + last 5 lines on success, `FAIL` + matched error lines + last 40 on failure. Preserves the command's exit code.
+
+```bash
+bash .claude/scripts/run-quiet.sh npm test
+bash .claude/scripts/run-quiet.sh terraform plan
+```
+
+## state-status.sh
+
+~15-line digest of the gated-workflow state files (`progress.txt` + `milestone-status.txt`) — Gates, Milestones, per-milestone features, awaiting-build items — replacing full re-reads of five documents. Also provides the buildable gate used by `/build`.
+
+```bash
+bash .claude/scripts/state-status.sh [repo-root]                        # digest
+bash .claude/scripts/state-status.sh --check-buildable "Feature NN.M"   # exit 0 iff buildable
+```
+
+- A feature is buildable iff its header is `[~]` **and** its block contains the literal phrase `planned, awaiting build`.
+- Milestone files are discovered in both the flat (`milestones/*/milestone-status.txt`) and namespaced (`.project/*/milestones/*/milestone-status.txt`) layouts.
+- `CC_MILESTONE_GLOB` (space-separated globs, evaluated from the repo root) overrides discovery.
+
+## check.sh
+
+Self-test harness for the whole toolkit: `bash -n` on every shell script, `node --check` on the hooks, jq verdict-parsing fixtures for codex-review, state-status fixtures in both layouts, heredoc-hook deny/allow fixtures, run-quiet exit-code tests, and branch-sync base-resolution tests.
+
+```bash
+bash scripts/claude-toolkit/check.sh   # bundle layout (this repository)
+bash .claude/scripts/check.sh          # installed layout (consumer repository)
+```
+
+Exit 0 iff every fixture passes. The installer behavior itself is covered separately by `tests/installer-claude-toolkit.bats`.
+
+## Hooks
+
+### block-heredoc-commit.js — `PreToolUse` / `Bash`
+
+Parses the proposed Bash command; if it is a `git commit` using a heredoc or an `-m` argument containing a newline, returns `permissionDecision: deny` with guidance to use `gcommit` / `git commit -F`. Unparseable input never blocks (fails open). Timeout 5s.
+
+### lint-md-on-edit.js — `PostToolUse` / `Edit|Write`
+
+When the edited file ends in `.md`/`.markdown`, runs `markdownlint-cli2 --fix` on it (path resolved absolute to guard against leading-`-` filenames). Silent and non-blocking; a missing `markdownlint-cli2` binary is a silent no-op — the hook calls the bare binary with no `npx` fallback by design (a PostToolUse hook must be fast and silent). Timeout 15s.
+
+## Environment variables
+
+| Variable | Used by | Effect |
+|---|---|---|
+| `CC_BASE_BRANCH` | branch-sync.sh | Overrides base-branch resolution (highest precedence) |
+| `CC_MILESTONE_GLOB` | state-status.sh | Overrides milestone-status file discovery globs |
+| `TMPDIR` | run-quiet.sh, check.sh | Log/fixture location (defaults to `/tmp`) |

--- a/docs/skills/build.md
+++ b/docs/skills/build.md
@@ -3,6 +3,7 @@
 **Source:** `skills/project/build/`
 **Command:** `/build`
 **Activation:** Manual only (`disable-model-invocation: true`) -- invoked via slash command. Not auto-triggered by conversational phrases.
+**Requires:** `.claude/scripts/gcommit` — every commit in the build loop is file-based (Commit Command Protocol D-03). Install it with `bash scripts/claude-toolkit/install.sh <target-repo-path>`; see [SCRIPTS.md](../SCRIPTS.md#claude-toolkit).
 
 ## Purpose
 

--- a/docs/skills/build.md
+++ b/docs/skills/build.md
@@ -34,11 +34,11 @@ Before reading the feature plan, performs an incremental refresh of `.project/{s
 
 ### 3. Sub-Feature Execution
 
-Loads the feature plan from the path recorded in `milestone-status.txt`. Parses the Sub-Features checklist and finds the first unchecked `[ ]` sub-feature (auto-resume mechanism for multi-session builds). For each sub-feature in order:
+Loads the feature plan from the path recorded in `milestone-status.txt`. Parses the Sub-Features checklist and finds the first unchecked `[ ]` sub-feature (auto-resume mechanism for multi-session builds). Feature-level sections (Approach, Interface Contracts, architecture doc) are read **once** when the loop starts — not re-read per sub-feature. For each sub-feature in order:
 
-1. Reads the sub-feature description, Approach, Interface Contracts, Files to Create/Modify, and architecture doc
+1. Reads only this sub-feature's description from the plan (re-opening a feature-level section only when it specifically applies)
 2. Implements the sub-feature -- writes actual code in the user's codebase
-3. Commits the sub-feature with message format `feat(<feature-slug>): SF-N <name>`
+3. Commits the sub-feature via `bash .claude/scripts/gcommit` (Commit Command Protocol D-03 — never a heredoc or multi-line `-m`) with message format `feat(<feature-slug>): SF-N <name>`
 4. Marks the sub-feature `[x]` in the feature plan
 5. Updates `milestone-status.txt` sub-feature count
 6. Displays the full Sub-Features checklist with current marks and announces the next sub-feature

--- a/docs/skills/create-prd.md
+++ b/docs/skills/create-prd.md
@@ -104,6 +104,7 @@ Presents a summary: artifact names, feature count, configuration parameter count
 - Updating an existing PRD — edit the file directly
 - Projects so small they don't warrant a PRD (a single function, a one-off script)
 - When the architecture is already fully defined and you only need a progress file
+- When the working directory's `progress.txt` contains `## Gates` / `## Milestones` sections — that repo is under `/project` (gated) management. The skill stops rather than overwrite a gated `progress.txt` with the light schema; continue with `/project`, or run `/create-prd` from a dedicated subdirectory
 
 ## Related Skills
 

--- a/docs/skills/red-team.md
+++ b/docs/skills/red-team.md
@@ -1,0 +1,79 @@
+# /red-team
+
+**Source:** `skills/red-team/`
+**Command:** `/red-team`
+**Activation:** Manual only (`disable-model-invocation: true`) -- invoked via slash command. Not auto-triggered by conversational phrases.
+
+## Purpose
+
+Adversarial review skill for any artifact -- code, infrastructure, architecture docs, PRDs, or proposals. Spawns parallel sub-agents (Opus), each reviewing through a different adversarial lens, plus a dedicated synthesis agent that consolidates all findings into a single report under `docs/red-team/{slug}-{nn}/`. Findings are evidence-based and quantified: every finding cites line numbers or quoted text, empty categories state what was examined, and hedged findings ("might", "perhaps") are discarded. Supports an optional `--debate` mode where green-team defenders challenge findings before synthesis.
+
+## When to Use
+
+- Red-teaming a design, PRD, proposal, or architecture document before committing to it
+- Adversarially reviewing code or infrastructure (Terraform, CDK, CloudFormation) for flaws, gaps, and risks
+- When asked to "find holes in", "challenge my design", or "what could go wrong"
+
+## When NOT to Use
+
+- General code review, proofreading, or style feedback (non-adversarial review)
+- Technical research questions (use `/spike`, which embeds its own red-team pass)
+- Complexity/YAGNI gating of a diff or plan (use `/over-engineering-review`)
+
+## Behavior
+
+### 1. Target Resolution
+
+Parses the invocation argument as an explicit file path, glob pattern, or natural language reference ("the PRD", "my design"); with no argument, resolves from conversation context. Missing paths, empty globs, and ambiguous references trigger `AskUserQuestion` with likely alternatives. Globs matching more than 10 files require confirmation. Multi-file targets are concatenated with `=== path ===` separators. Validates that at least one non-empty file was read before proceeding.
+
+### 2. Classification and Lens Selection
+
+Classifies the artifact type (Code, Infrastructure, Architecture/Design, PRD/Proposal, Other) using three signals in priority order: file extension/path, content structure, and user hint -- the user hint is the tiebreaker and authoritative when the user explicitly names a type. The type maps to 2-3 default lenses (e.g., Code gets Security, Design, Completeness; PRD gets Assumptions, Completeness, Feasibility). The user can override with explicit lens selection or exclusion. All 8 lenses: Security, Assumptions, Completeness, Design, Feasibility, Operational, Cost, Compliance. The classification and selected lenses are displayed before agents spawn; low-confidence classifications are flagged for correction. Artifacts over 1500 lines are chunked into labeled sections with a full-artifact summary per `references/chunking-rules.md`.
+
+### 3. Approval Gate and Agent Spawn
+
+Derives the output path `docs/red-team/{slug}-{nn}/` (kebab-case artifact name plus incrementing run number) and presents the proposed agent team via `AskUserQuestion` (Approve / Modify / Cancel). Passing `--auto` skips the gate only when fewer than 5 agents are selected -- at 5+ the gate is mandatory as a cost checkpoint. Each lens persona resolves through a 3-tier hierarchy: project override (`.claude/red-team/{lens}-agent.md`), bundled persona (`references/{lens}-agent.md`), then dynamic generation. All agents spawn in parallel in a single message, model `opus`, each writing `{lens}-findings.md` to the run directory. Security agents additionally get `Bash` for verification. Output is then verified for structural compliance against `references/findings-format.md` and recorded Pass/Partial/Fail per agent.
+
+### 4. Debate Phase (--debate only)
+
+When `--debate` is passed, spawns one green-team defender per lens (parallel, Opus) that sends evidence-based rebuttals to its paired red-team agent via Agent Teams messaging. Red-team agents assign each finding a status -- Sustained, Rebutted, or Contested -- and rewrite their findings files with Defense and Status fields. Default 1 round; `--rounds N` runs up to 5. Failed green-team agents or communication failures degrade gracefully: affected findings are marked Sustained and the fallback is noted in the methodology.
+
+### 5. Synthesis
+
+Spawns a single dynamically generated synthesis agent (Opus) after all red-team agents complete. It receives all findings files, the report template from `references/report-template.md`, agent compliance results, and run metadata, and writes `CONSOLIDATED-REPORT.md` to the run directory. The report is verified to contain an Executive Summary, Methodology, and total findings count; if the write fails, the report content is displayed for manual save. Partial agent failures do not block synthesis -- only a total failure aborts.
+
+### 6. Completion Summary
+
+Displays the artifact, overall risk rating (Critical/High/Medium/Low), finding counts by severity (plus Sustained/Rebutted/Contested counts in debate mode), the report path, and suggested next steps based on findings.
+
+## Artifacts
+
+| Artifact | Path | Created By |
+|----------|------|------------|
+| Per-lens findings | `docs/red-team/{slug}-{nn}/{lens}-findings.md` | Red-team agents (updated with Defense/Status in debate mode) |
+| Consolidated report | `docs/red-team/{slug}-{nn}/CONSOLIDATED-REPORT.md` | Synthesis agent |
+
+## Skill Files
+
+```
+skills/red-team/
++-- SKILL.md                              # Flow controller (5 steps + error handling)
++-- CONCEPT.md                            # Design concept
++-- MVP.md                                # MVP scope
++-- references/
+    +-- agent-prompt-template.md          # Red-team agent prompt assembly template
+    +-- {lens}-agent.md                   # 8 bundled personas: security, assumptions, completeness, design, feasibility, operational, cost, compliance
+    +-- chunking-rules.md                 # Large-artifact splitting, labeling, and section assignment
+    +-- debate-rules.md                   # Green-team protocol, personas, and status labels
+    +-- findings-format.md                # Structured findings output spec and compliance checklist
+    +-- persona-resolution.md             # Dynamic persona generation and mismatch detection
+    +-- report-template.md                # Consolidated report structure and synthesis rules
+    +-- synthesis-prompt-template.md      # Synthesis agent prompt assembly template
+```
+
+## Related Skills
+
+| Skill | Relationship |
+|-------|-------------|
+| `/spike` | Runs its own embedded red-team pass on research findings; use `/spike` for research questions, `/red-team` for existing artifacts |
+| `/over-engineering-review` | Complementary review focused on complexity and YAGNI/KISS, not adversarial risk finding |

--- a/docs/skills/spike.md
+++ b/docs/skills/spike.md
@@ -33,11 +33,11 @@ Reads `progress.txt` from the project root. Gathers the user's research question
 
 ### 2. Research Agent
 
-Spawns a sub-agent to investigate the research question. The agent uses web search (WebFetch), codebase tools (Read, Glob, Grep, Bash), and documentation to research each tool in the available tooling list. Produces structured findings including methodology, per-tool analysis (version, compatibility, documentation, community activity, known issues, integration), comparison matrix, and findings summary. Writes results to `/tmp/spike-research-findings.md`.
+Spawns a sub-agent to investigate the research question. The agent uses web search (WebFetch), codebase tools (Read, Glob, Grep, Bash), and documentation to research each tool in the available tooling list. Produces structured findings including methodology, per-tool analysis (version, compatibility, documentation, community activity, known issues, integration), comparison matrix, and findings summary. Writes results to `${TMPDIR:-/tmp}/spike-<slug>-research-findings.md` (slug-namespaced so concurrent spikes never collide).
 
 ### 3. Red-Team Agent
 
-After the research agent completes, spawns a second sub-agent with an explicitly adversarial posture. The red-team agent reads the research findings and independently verifies claims using its own tool access (same tools as research agent per D-03). Challenges factual errors, missing alternatives, flawed reasoning, unverified assumptions, and version/compatibility issues. Quantifies verification effort (N of M claims checked). Writes structured critique to `/tmp/spike-redteam-findings.md`.
+After the research agent completes, spawns a second sub-agent with an explicitly adversarial posture. The red-team agent reads the research findings and independently verifies claims using its own tool access (same tools as research agent per D-03). Challenges factual errors, missing alternatives, flawed reasoning, unverified assumptions, and version/compatibility issues. Quantifies verification effort (N of M claims checked). Writes structured critique to `${TMPDIR:-/tmp}/spike-<slug>-redteam-findings.md`.
 
 ### 4. Artifact Assembly
 

--- a/rules/agent-delegation.md
+++ b/rules/agent-delegation.md
@@ -1,18 +1,26 @@
 # Multi-Agent Delegation
 
-> Delegate bulk discovery, repetitive generation, and repo-wide search to specialized sub-agents. The coordinator (Sonnet) keeps architectural ownership. State the delegation decision before the first tool call on any bulk task.
+> Delegate bulk discovery, repetitive generation, and repo-wide search to specialized sub-agents. The main thread (coordinator) keeps architectural ownership. State the delegation decision before the first tool call on any bulk task.
 
 ---
 
 ## Trigger Card
 
+Maps to agents actually spawnable in this harness (the `Agent` tool's `subagent_type`,
+plus `model` overrides). Names like Gemini/Sonnet/Haiku/Opus are NOT spawnable agent
+types here — use the real agents below, and the `model` override for cost/depth tuning.
+
 ```text
 Bulk discovery (read-only)             → Explore
-Log retrieval / output parsing         → Haiku
-Repo-wide search / dependency map      → Gemini
-Architecture / unresolved blocker      → Opus
-Terminal / scripting workflows         → Codex
-Default                                → Sonnet (me)
+Locate code / "where is X" (compressed)→ cavecrew-investigator
+Multi-step search / research           → general-purpose
+Architecture / planning                → Plan
+1-2 file surgical edit                 → cavecrew-builder
+Diff / branch review                   → cavecrew-reviewer
+Terminal / scripting / second-opinion  → codex:codex-rescue
+Cheap localized task                   → Agent + model: haiku
+Deep reasoning / hard blocker          → Agent + model: opus
+Default                                → main thread (me)
 ```
 
 ---
@@ -41,9 +49,9 @@ Delegation should optimize for:
 
 ---
 
-## Primary Coordinator (Sonnet)
+## Primary Coordinator (main thread)
 
-Sonnet is the default development and orchestration agent.
+The main thread is the default development and orchestration agent.
 
 Responsibilities:
 
@@ -54,7 +62,7 @@ Responsibilities:
 - Validate correctness before merge
 - Handle nuanced reasoning and refactoring
 
-Even when delegation occurs, Sonnet remains responsible for:
+Even when delegation occurs, the main thread remains responsible for:
 
 - final integration
 - consistency validation
@@ -65,14 +73,29 @@ Even when delegation occurs, Sonnet remains responsible for:
 
 ## Delegation Matrix
 
-| Agent       | Delegate When... | Strengths | Weaknesses |
-|-------------|------------------|-----------|------------|
-| **Sonnet**  | Default for feature development, refactoring, debugging, and coordinated multi-file changes | Best balance of reasoning, context retention, and architectural cohesion | Less cost-efficient for repetitive boilerplate |
-| **Haiku**   | Generating tests, documentation, schema mappings, repetitive CRUD, simple UI/CSS updates, log retrieval and output parsing | Extremely fast and low-cost for localized implementation tasks | Weak at deep architectural reasoning and complex dependencies |
-| **Opus**    | Resolving unresolved system failures, security design, difficult debugging, or core architecture decisions | Maximum reasoning depth and abstract systems thinking | Highest latency and cost |
-| **Codex**   | Terminal workflows, shell scripts, deterministic implementation tasks, regex transformations, tooling glue code | Strong execution-oriented accuracy and structured implementation | Smaller effective context and weaker project-wide cohesion |
-| **Gemini**  | Repository-wide discovery, large log analysis, legacy codebase scanning, long-document ingestion | Massive context window enables large-scale analysis | Lower implementation precision; requires validation before merge |
-| **Explore** | Bulk read-only discovery, multi-file enumeration, "where is X defined / which files reference Y", initial codebase reconnaissance | Built-in Claude Code subagent; preserves the main context window; supports quick / medium / very-thorough search breadth | Read-only (cannot edit); reads excerpts, not whole files — misses content past its read window; not for cross-file consistency checks or open-ended analysis |
+These are the real spawnable agents in this harness (`Agent` tool `subagent_type`). For
+cost/depth tuning, pass a `model` override (`haiku`/`sonnet`/`opus`) on an `Agent` call
+rather than treating the model name as an agent type.
+
+| Agent | Delegate When... | Strengths | Weaknesses |
+|-------|------------------|-----------|------------|
+| **main thread (me)** | Default for feature development, refactoring, debugging, and coordinated multi-file changes | Holds architectural context; integrates delegated outputs | Consumes the primary context window on bulk work |
+| **Explore** | Bulk read-only discovery, multi-file enumeration, "where is X defined / which files reference Y", initial codebase reconnaissance | Built-in subagent; preserves the main context window; quick / medium / very-thorough breadth | Read-only; reads excerpts not whole files; not for cross-file consistency checks |
+| **cavecrew-investigator** | Locate code: "where is X defined", "what calls Y", "list uses of Z", map a directory | Read-only locator; caveman-compressed output (~60% fewer tokens back to main) | Refuses to suggest fixes; locate-only |
+| **general-purpose** | Multi-step search/research, open-ended "find the thing" when first tries may miss, repo-wide dependency tracing | Full toolset; persistent multi-step reasoning | Heavier than Explore; validate output before merge |
+| **Plan** | Architecture decisions, designing an implementation strategy before coding | Returns step-by-step plans, identifies critical files, weighs trade-offs | Read-only (cannot edit); planning only |
+| **cavecrew-builder** | Surgical 1-2 file edit: typo fix, single-function rewrite, mechanical rename, comment removal | Bounded edits; caveman diff receipt | Hard-refuses 3+ file scope; not for new features/files |
+| **cavecrew-reviewer** | Diff / branch / file review, PR audit | One line per finding, severity-tagged, no scope creep | Review only; skips pure formatting nits |
+| **codex:codex-rescue** | Terminal/scripting workflows, second implementation/diagnosis pass, deeper root-cause, hand off a substantial coding task to Codex | Strong execution-oriented accuracy; independent engine for second opinion | External runtime; validate before merge |
+| **Agent + `model: haiku`** | Cheap localized tasks: tests, docs, schema mappings, repetitive CRUD, log/output parsing | Fast, low-cost | Weak at deep architectural reasoning |
+| **Agent + `model: opus`** | Unresolved failures, security design, hard debugging, core architecture | Maximum reasoning depth | Highest latency and cost |
+
+**Plugin availability.** `cavecrew-*` agents come from the `caveman` plugin and
+`codex:codex-rescue` from the `codex` plugin — neither ships with Claude Code. In a
+harness without them, route those rows to the built-ins: `cavecrew-investigator` →
+`Explore`, `cavecrew-builder` → `Agent + model: haiku` (or the main thread),
+`cavecrew-reviewer` → `general-purpose`, `codex:codex-rescue` → `general-purpose`.
+Check the available-agents list in your session before delegating to a plugin agent.
 
 ---
 
@@ -116,12 +139,12 @@ When beneficial, use multiple specialized agents simultaneously.
 
 Example workflow:
 
-- **Explore** → in-session bulk reads and multi-file enumeration
-- **Gemini** → cross-repository discovery and long-context dependency tracing
-- **Haiku** → tests, docs, and repetitive support code
-- **Codex** → scripts, tooling, transformations, terminal workflows
-- **Sonnet** → orchestration, implementation coordination, integration
-- **Opus** → escalation for unresolved architectural or reasoning issues
+- **Explore** / **cavecrew-investigator** → in-session bulk reads, enumeration, code-locate
+- **general-purpose** → repo-wide discovery and multi-step dependency tracing
+- **Agent + `model: haiku`** → tests, docs, and repetitive support code
+- **codex:codex-rescue** → scripts, tooling, transformations, terminal workflows
+- **main thread (me)** → orchestration, implementation coordination, integration
+- **Agent + `model: opus`** → escalation for unresolved architectural or reasoning issues
 
 Parallel delegation should improve throughput without fragmenting architectural ownership.
 
@@ -131,29 +154,31 @@ Parallel delegation should improve throughput without fragmenting architectural 
 
 | Trigger Phrase | Delegate To | Purpose |
 |---|---|---|
-| "Generate exhaustive unit tests for..." | Haiku | Fast low-cost test generation |
-| "Update docs / comments / schema mappings..." | Haiku | Repetitive maintenance tasks |
-| "Find where X is defined..." | Explore | In-session bulk read and search |
+| "Generate exhaustive unit tests for..." | Agent + `model: haiku` | Fast low-cost test generation |
+| "Update docs / comments / schema mappings..." | Agent + `model: haiku` | Repetitive maintenance tasks |
+| "Find where X is defined..." | cavecrew-investigator | Compressed code-locate |
 | "Enumerate files matching..." | Explore | Multi-file read-only enumeration |
-| "Scan the repository for..." | Gemini | Repository-wide discovery |
-| "Trace all usages of..." | Gemini | Long-context dependency analysis |
-| "Design the architecture for..." | Opus | Deep systems reasoning |
-| "Investigate unresolved multi-system failures..." | Opus | Advanced debugging escalation |
-| "Refactor this subsystem safely..." | Sonnet | Coordinated multi-file refactoring |
-| "Implement production-ready feature..." | Sonnet | Default execution path |
-| "Write a shell script to..." | Codex | CLI and scripting workflows |
-| "Transform files using regex or automation..." | Codex | Deterministic transformation tasks |
+| "Scan the repository for..." | general-purpose | Repository-wide discovery |
+| "Trace all usages of..." | general-purpose | Multi-step dependency tracing |
+| "Review this diff / PR..." | cavecrew-reviewer | Severity-tagged diff review |
+| "Design the architecture for..." | Plan | Implementation strategy + critical files |
+| "Investigate unresolved multi-system failures..." | Agent + `model: opus` | Advanced debugging escalation |
+| "Second opinion / root-cause this..." | codex:codex-rescue | Independent diagnosis pass |
+| "Refactor this subsystem safely..." | main thread (me) | Coordinated multi-file refactoring |
+| "Implement production-ready feature..." | main thread (me) | Default execution path |
+| "Write a shell script to..." | codex:codex-rescue | CLI and scripting workflows |
+| "Surgical 1-2 file edit / rename..." | cavecrew-builder | Bounded format-preserving edit |
 
 ---
 
 ## Escalation Logic
 
-1. Start with **Sonnet**
-2. Use **Explore** for in-session bulk reads and search
-3. Delegate repetitive or localized tasks to **Haiku**
-4. Use **Gemini** for repository-wide analysis or long-context work
-5. Use **Codex** for execution-heavy or tooling-oriented workflows
-6. Escalate to **Opus** when:
+1. Start on the **main thread (me)**
+2. Use **Explore** / **cavecrew-investigator** for in-session bulk reads, search, code-locate
+3. Delegate repetitive or localized tasks to **Agent + `model: haiku`**
+4. Use **general-purpose** for repository-wide or multi-step discovery work
+5. Use **codex:codex-rescue** for execution-heavy, tooling, or second-opinion workflows
+6. Escalate to **Agent + `model: opus`** when:
    - blocked after multiple iterations
    - architectural uncertainty persists
    - debugging becomes non-deterministic
@@ -165,21 +190,21 @@ Escalation should be intentional, not automatic.
 
 ## Repository Discovery Guidance
 
-Use **Explore** when:
+Use **Explore** (or **cavecrew-investigator** for compressed locate-only output) when:
 
 - searching the current repository in-session
 - enumerating files by pattern
 - locating where a symbol or string is defined
 - preserving the main context window during reconnaissance
 
-Use **Gemini** when:
+Use **general-purpose** when:
 
-- searching legacy or massive repositories
-- tracing dependency chains across millions of lines
-- analyzing extensive logs
-- ingesting long technical documentation
+- the search is open-ended and the first few tries may miss
+- tracing dependency chains across many files
+- multi-step research that needs the full toolset, not just excerpts
+- analyzing logs or long documents in a separate context
 
-The split: Explore for in-session reads where the context window is not the bottleneck; Gemini for long-context workloads where it is. Both are discovery tools — implementation generated from their analysis must be validated by Sonnet or Opus before merge.
+The split: Explore/cavecrew-investigator for fast in-session reads; general-purpose for open-ended multi-step discovery that needs persistence and the full toolset. Both are discovery agents — implementation generated from their analysis must be validated on the main thread (escalate to `model: opus` for hard calls) before merge.
 
 ---
 

--- a/scripts/claude-toolkit/README.md
+++ b/scripts/claude-toolkit/README.md
@@ -17,6 +17,21 @@ bash scripts/claude-toolkit/install.sh --base-branch develop <target-repo-path>
 
 Restart Claude Code in the target repo afterwards.
 
+### Scope: scripts and hooks only
+
+This installer copies **scripts and hooks**. It does **not** install skills, commands, or rules —
+those are copied with `cp -r` (see [docs/SKILLS.md](../../docs/SKILLS.md#consuming-skills) and
+[docs/COMMANDS.md](../../docs/COMMANDS.md#consuming-commands)).
+
+It is, however, a prerequisite for two of them, which invoke these scripts by path:
+
+| Consumer | Requires | Effect if missing |
+|---|---|---|
+| `/build` (`skills/project/build/`) | `gcommit` | Commit step fails on a missing script |
+| `/start-feature-auto` (`commands/start-feature-auto.md`) | `codex-review.sh` | Review records as skipped; feature still closes |
+
+Install the toolkit first, then copy the skills.
+
 ## What gets installed
 
 | Item | Destination | Effect |

--- a/scripts/claude-toolkit/README.md
+++ b/scripts/claude-toolkit/README.md
@@ -1,0 +1,79 @@
+# Claude Code Toolkit
+
+Battle-tested helper scripts and tool hooks for Claude Code sessions: file-based
+commits that can never break on quoting, a hardened Codex review wrapper, quiet
+command execution, gated-workflow state digests, and deterministic markdown
+hygiene. Extracted from a production GitOps repository after several weeks of
+live use.
+
+## Quick start
+
+```bash
+bash scripts/claude-toolkit/install.sh <target-repo-path>
+
+# optionally pin the integration base branch for branch-sync.sh:
+bash scripts/claude-toolkit/install.sh --base-branch develop <target-repo-path>
+```
+
+Restart Claude Code in the target repo afterwards.
+
+## What gets installed
+
+| Item | Destination | Effect |
+|---|---|---|
+| `gcommit` | `.claude/scripts/` | Commit via message file (`git commit -F`) — quoting can never break |
+| `branch-sync.sh` | `.claude/scripts/` | Reset a feature branch onto the integration base after a squash-merge |
+| `codex-review.sh` | `.claude/scripts/` | Hardened Codex review wrapper: closed stdin, timeout, read-only sandbox, `VERDICT: PASS/FAIL` |
+| `run-quiet.sh` | `.claude/scripts/` | Run any command, log fully to `$TMPDIR`, print only a summary |
+| `state-status.sh` | `.claude/scripts/` | ~15-line digest of gated-workflow state files + `--check-buildable` gate |
+| `check.sh` | `.claude/scripts/` | Self-test harness for every script and hook in this toolkit |
+| `hooks/block-heredoc-commit.js` | `.claude/hooks/` | PreToolUse/Bash — denies `git commit` with heredoc or multi-line `-m`, steers to gcommit |
+| `hooks/lint-md-on-edit.js` | `.claude/hooks/` | PostToolUse/Edit\|Write — auto-fixes edited markdown via `markdownlint-cli2` |
+| Hook wiring | `.claude/settings.json` | jq-merged, versioned markers (`# cc-toolkit-heredoc-block v1`, `# cc-toolkit-lint-md v1`); idempotent; migrates pre-existing unmarked entries |
+| Guidance block | `CLAUDE.md` | Sentinel-guarded (`<!-- BEGIN CLAUDE-TOOLKIT -->`) Git/commit + review rules |
+| `.cc-base-branch` | repo root | Only with `--base-branch`, only if the file is absent — never overwritten |
+
+Everything is invoked with `bash <script>`; the installer never sets an
+executable bit.
+
+## Script reference
+
+| Script | Invocation | Notes |
+|---|---|---|
+| gcommit | `bash .claude/scripts/gcommit "subject"` or pipe a full message on stdin | Also accepts a message-file path as the argument |
+| branch-sync.sh | `bash .claude/scripts/branch-sync.sh [feature-branch]` | Base branch: `$CC_BASE_BRANCH` → `.cc-base-branch` → origin HEAD. Interactive confirm; refuses a dirty tree |
+| codex-review.sh | `bash .claude/scripts/codex-review.sh --diff \| --staged \| --commits A..B \| FILE...` | Exit 0 = PASS, 1 = FAIL, **2 = no verdict (timeout/error) — never treat as PASS** |
+| run-quiet.sh | `bash .claude/scripts/run-quiet.sh <cmd> [args...]` | Preserves the command's exit code |
+| state-status.sh | `bash .claude/scripts/state-status.sh [root]` / `--check-buildable SLUG [root]` | Layout override: `CC_MILESTONE_GLOB` |
+| check.sh | `bash .claude/scripts/check.sh` (installed) / `bash scripts/claude-toolkit/check.sh` (bundle) | Runs syntax + fixture tests for the whole toolkit |
+
+## Dependencies
+
+| Dependency | Needed by | Installer behavior |
+|---|---|---|
+| `jq` | installer, codex-review.sh, check.sh | **Hard prerequisite** |
+| `node` | both hooks, check.sh | **Hard prerequisite** |
+| `markdownlint-cli2` | lint-md-on-edit hook | Warn only — the hook calls the **bare binary** (no `npx` fallback, by design: a PostToolUse hook must be fast and silent). Absent = silent no-op |
+| `codex` CLI | codex-review.sh | Warn only |
+| GNU `timeout` / `gtimeout` | codex-review.sh | macOS: `brew install coreutils` |
+
+## Consumer notes
+
+- **Consumers with hand-written Git/commit guidance in `CLAUDE.md`** should
+  dedupe it against the installed sentinel block — the installer appends, it
+  does not replace hand-written sections.
+- **`assets/eslint.config.mjs`** is not auto-installed. Copy it to the consumer
+  repo root only if that repo's pre-commit runs `npx eslint` and the repo has no
+  eslint config (the new `.claude/hooks/*.js` files would otherwise break the
+  hook). It would clobber an existing eslint setup — hence manual.
+- The skills/commands in this library reference these scripts at their installed
+  paths (`bash .claude/scripts/...`), assuming the repo root as working
+  directory.
+
+## Self-test
+
+```bash
+bash scripts/claude-toolkit/check.sh     # bundle layout
+bash .claude/scripts/check.sh            # installed layout
+bats tests/installer-claude-toolkit.bats # installer behavior
+```

--- a/scripts/claude-toolkit/README.md
+++ b/scripts/claude-toolkit/README.md
@@ -17,20 +17,41 @@ bash scripts/claude-toolkit/install.sh --base-branch develop <target-repo-path>
 
 Restart Claude Code in the target repo afterwards.
 
-### Scope: scripts and hooks only
+### Scope
 
-This installer copies **scripts and hooks**. It does **not** install skills, commands, or rules —
-those are copied with `cp -r` (see [docs/SKILLS.md](../../docs/SKILLS.md#consuming-skills) and
-[docs/COMMANDS.md](../../docs/COMMANDS.md#consuming-commands)).
+Installs **scripts, hooks, and the gated project skill suite**. Commands and rules are not installed
+— copy those with `cp` (see [docs/COMMANDS.md](../../docs/COMMANDS.md#consuming-commands) and
+[docs/RULES.md](../../docs/RULES.md)). Pass `--no-skills` for scripts and hooks only.
 
-It is, however, a prerequisite for two of them, which invoke these scripts by path:
+Installing the suite here is deliberate: `/build` invokes `gcommit` and `/start-feature-auto`
+invokes `codex-review.sh` by path, so shipping the skills alongside the scripts they call keeps the
+pair consistent.
 
 | Consumer | Requires | Effect if missing |
 |---|---|---|
-| `/build` (`skills/project/build/`) | `gcommit` | Commit step fails on a missing script |
-| `/start-feature-auto` (`commands/start-feature-auto.md`) | `codex-review.sh` | Review records as skipped; feature still closes |
+| `/build` | `gcommit` | Commit step fails on a missing script |
+| `/start-feature-auto` (copy the command separately) | `codex-review.sh` | Review records as skipped; feature still closes |
 
-Install the toolkit first, then copy the skills.
+### Skill layout: the suite is flattened
+
+The library nests the suite as `skills/project/<sub>/` for authoring, but Claude Code scans
+`.claude/skills/` **one level deep** and derives each slash command from the **directory name**. The
+installer therefore flattens:
+
+```
+skills/project/SKILL.md + references/   ->  .claude/skills/project/     -> /project
+skills/project/build/                   ->  .claude/skills/build/       -> /build
+skills/project/define/                  ->  .claude/skills/define/      -> /define
+        (design, milestone, plan-feature, spike likewise)
+```
+
+A wholesale `cp -r skills/project/ <target>/.claude/skills/project/` would leave all six sub-skills
+one level too deep to be discovered, while `/project` routes to them by bare name — the workflow
+would dead-end at the first gate.
+
+Skill copies are an **overlay**: files you add inside an installed skill directory survive an
+upgrade, and nothing is deleted. A stale file from an older version is not pruned — remove the skill
+directory by hand for a clean reinstall.
 
 ## What gets installed
 

--- a/scripts/claude-toolkit/assets/eslint.config.mjs
+++ b/scripts/claude-toolkit/assets/eslint.config.mjs
@@ -1,0 +1,38 @@
+// eslint.config.mjs — baseline flat config for consumer repos.
+//
+// Only needed when the consumer's pre-commit runs `npx eslint` on staged JS/TS.
+// A repo with no prior JS and no eslint config errors ("couldn't find
+// eslint.config.*") the moment the toolkit's hooks/*.js are added. This provides
+// the required config with Node globals so tooling scripts lint cleanly. No
+// rules are enforced yet — add them when the repo grows real application JS/TS.
+// Copy manually to the consumer repo root; the installer does not install this
+// (it would clobber an existing eslint setup).
+export default [
+  // CommonJS tooling scripts (hooks/*.js use require/module).
+  {
+    files: ['**/*.{js,cjs}'],
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: 'commonjs',
+      globals: {
+        process: 'readonly',
+        require: 'readonly',
+        module: 'writable',
+        __dirname: 'readonly',
+        console: 'readonly',
+      },
+    },
+  },
+  // ESM files (.mjs, e.g. this config) — parse import/export correctly.
+  {
+    files: ['**/*.mjs'],
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: 'module',
+      globals: {
+        process: 'readonly',
+        console: 'readonly',
+      },
+    },
+  },
+];

--- a/scripts/claude-toolkit/branch-sync.sh
+++ b/scripts/claude-toolkit/branch-sync.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# branch-sync.sh — after a PR squash-merge, make the local feature branch identical
+# to the repo's integration branch. Replaces the 15× "squashed and merged — synch the
+# changes back" manual prompt.
+#
+# Squash-merge means your local commits are already IN the integration branch (as one
+# squashed commit); a plain merge/rebase produces conflicts. The correct move is a hard
+# reset onto the integration branch.
+#
+# Integration (base) branch is resolved in this order — so repos that merge into a
+# non-default branch (e.g. `migration`, not `main`) work correctly:
+#   1. $CC_BASE_BRANCH environment variable
+#   2. .cc-base-branch file at the repo top level (one line, the branch name)
+#   3. the remote's default HEAD branch (git remote show origin)
+#
+# Usage: branch-sync.sh [feature-branch]   (defaults to current branch)
+set -euo pipefail
+
+TOP="$(git rev-parse --show-toplevel)"
+
+resolve_base_branch() {
+  if [[ -n "${CC_BASE_BRANCH:-}" ]]; then
+    printf '%s\n' "$CC_BASE_BRANCH"; return
+  fi
+  if [[ -f "$TOP/.cc-base-branch" ]]; then
+    head -n 1 "$TOP/.cc-base-branch" | tr -d '[:space:]'; return
+  fi
+  git remote show origin | sed -n 's/.*HEAD branch: //p'
+}
+
+BR="${1:-$(git branch --show-current)}"
+BASE="$(resolve_base_branch)"
+
+if [[ -z "$BASE" ]]; then
+  echo "branch-sync: could not resolve an integration branch (set CC_BASE_BRANCH or .cc-base-branch)" >&2
+  exit 1
+fi
+if [[ -z "$BR" || "$BR" == "$BASE" ]]; then
+  echo "branch-sync: on the integration branch '$BASE' (or detached) — nothing to sync" >&2
+  exit 1
+fi
+
+git show-ref --verify --quiet "refs/heads/$BR" \
+  || { echo "branch-sync: no local branch named '$BR'" >&2; exit 1; }
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "branch-sync: working tree dirty — commit or stash first" >&2
+  exit 1
+fi
+
+CURRENT="$(git branch --show-current)"
+echo "Current branch: ${CURRENT:-<detached>}  |  Feature branch to reset: $BR  |  Integration branch: $BASE"
+
+git fetch origin "$BASE"
+git show-ref --verify --quiet "refs/remotes/origin/$BASE" \
+  || { echo "branch-sync: origin/$BASE not found after fetch" >&2; exit 1; }
+
+AHEAD="$(git rev-list --count "origin/${BASE}..${BR}")"
+echo "Branch '$BR' has $AHEAD commit(s) not on origin/$BASE."
+echo "These are assumed to be already squash-merged; they will be DISCARDED locally."
+echo
+echo "WARNING: this runs 'git reset --hard origin/$BASE' on '$BR' and cannot be"
+echo "undone except via reflog. Only proceed if the PR from '$BR' was merged into '$BASE'."
+read -r -p "Reset '$BR' to origin/$BASE? [y/N] " ANSWER
+[[ "$ANSWER" == y* || "$ANSWER" == Y* ]] || { echo "aborted"; exit 1; }
+
+git checkout "$BR"
+git reset --hard "origin/$BASE"
+echo "Done: '$BR' == origin/$BASE. (Recovery if needed: git reflog)"

--- a/scripts/claude-toolkit/check.sh
+++ b/scripts/claude-toolkit/check.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# check.sh — syntax checks + fixture tests for every script in this toolkit.
+# Run after any change:
+#   bundle layout   : bash scripts/claude-toolkit/check.sh
+#   installed layout: bash .claude/scripts/check.sh
+#
+# shellcheck disable=SC2015,SC2181,SC2016
+# Test assertions use the `cond && ok "..." || bad "..."` idiom throughout.
+# ok() always returns 0, so the A&&B||C caveat (SC2015) does not apply here,
+# and checking $? after a subshell (SC2181) is deliberate for readability.
+# SC2016: the single-quoted JSON fixtures are intentionally literal (fake
+# command strings fed to the hook) — no expansion is wanted.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# Hook dir: an installed toolkit keeps hooks at .claude/hooks (sibling of
+# .claude/scripts/); the template bundle keeps them at scripts/claude-toolkit/hooks/
+# (subdir of the scripts). Support both.
+HOOK_DIR="$HERE/../hooks"
+[[ -f "$HOOK_DIR/block-heredoc-commit.js" ]] || HOOK_DIR="$HERE/hooks"
+PASS=0
+FAIL=0
+
+ok()   { echo "  ok: $1"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "== syntax =="
+for f in "$HERE"/*.sh "$HERE"/gcommit; do
+  if bash -n "$f" 2>/dev/null; then ok "bash -n $(basename "$f")"; else bad "bash -n $(basename "$f")"; fi
+done
+if node --check "$HOOK_DIR/block-heredoc-commit.js" 2>/dev/null; then
+  ok "node --check block-heredoc-commit.js"
+else
+  bad "node --check block-heredoc-commit.js"
+fi
+
+echo "== codex-review verdict parsing (jq fixture, no codex call) =="
+JQ_EXPR='[.[] | select(.item.type? == "agent_message") | .item.text] | last // empty'
+T="$(printf '%s\n' '{"item":{"type":"agent_message","text":"finding\nVERDICT: PASS"}}' | jq -rs "$JQ_EXPR")"
+grep -q '^VERDICT: PASS[[:space:]]*$' <<< "$T" && ok "PASS verdict recognized" || bad "PASS verdict recognized"
+T="$(printf '%s\n' '{"item":{"type":"agent_message","text":"finding\nVERDICT: FAIL"}}' | jq -rs "$JQ_EXPR")"
+grep -q '^VERDICT: FAIL[[:space:]]*$' <<< "$T" && ok "FAIL verdict recognized" || bad "FAIL verdict recognized"
+T="$(printf '%s\n' '{"item":{"type":"agent_message","text":"no verdict here"}}' | jq -rs "$JQ_EXPR")"
+if ! grep -qE '^VERDICT: (PASS|FAIL)' <<< "$T"; then ok "missing verdict detected"; else bad "missing verdict detected"; fi
+T="$(printf '%s\n' '{"item":{"type":"other"}}' | jq -rs "$JQ_EXPR")"
+[[ -z "$T" ]] && ok "non-agent events ignored" || bad "non-agent events ignored"
+
+echo "== state-status fixtures (real milestone-status schema) =="
+D="$(mktemp -d "${TMPDIR:-/tmp}/check-state.XXXXXX")"
+trap 'rm -rf "$D"' EXIT
+mkdir -p "$D/milestones/09-mixed"
+cat > "$D/progress.txt" <<'EOF'
+## Gates
+[x] Gate 3: Milestone Review  Approved
+## Milestones
+[~] Milestone 09: Mixed  milestones/09-mixed/  1/2 features complete
+EOF
+cat > "$D/milestones/09-mixed/milestone-status.txt" <<'EOF'
+# Milestone 09: Mixed
+
+## Features
+
+[x] Feature 09.1: completed thing
+    Notes: Gate 4 approved earlier (planned, awaiting build) — since completed.
+    Completed 2026-07-01
+
+[~] Feature 09.2: planned thing
+    Plan: plans/planned-thing.md
+    Notes: Gate-4 (2026-07-04): planned, awaiting build.
+
+[ ] Feature 09.3: unplanned thing
+    Plan: (not yet planned)
+EOF
+
+bash "$HERE/state-status.sh" --check-buildable "Feature 09.2" "$D" >/dev/null 2>&1 \
+  && ok "planned feature is BUILDABLE" || bad "planned feature is BUILDABLE"
+bash "$HERE/state-status.sh" --check-buildable "Feature 09.1" "$D" >/dev/null 2>&1 \
+  && bad "completed feature rejected (false positive!)" || ok "completed feature rejected"
+bash "$HERE/state-status.sh" --check-buildable "Feature 09.3" "$D" >/dev/null 2>&1 \
+  && bad "unplanned feature rejected (false positive!)" || ok "unplanned feature rejected"
+bash "$HERE/state-status.sh" --check-buildable "Feature 09.9" "$D" >/dev/null 2>&1 \
+  && bad "unknown slug rejected (false positive!)" || ok "unknown slug rejected"
+# capture first: grep -q's early exit would SIGPIPE the script under pipefail
+DIGEST="$(bash "$HERE/state-status.sh" "$D")"
+grep -q 'Feature 09.2' <<< "$DIGEST" \
+  && ok "digest lists awaiting-build feature" || bad "digest lists awaiting-build feature"
+
+echo "== state-status namespaced layout (.project/<slug>/milestones) =="
+N="$(mktemp -d "${TMPDIR:-/tmp}/check-state-ns.XXXXXX")"
+mkdir -p "$N/.project/robin/milestones/01-alpha"
+cat > "$N/progress.txt" <<'EOF'
+## Gates
+[x] Gate 3: Milestone Review  Approved
+## Milestones
+[~] Milestone 01: Alpha  .project/robin/milestones/01-alpha/  0/1 features complete
+EOF
+cat > "$N/.project/robin/milestones/01-alpha/milestone-status.txt" <<'EOF'
+# Milestone 01: Alpha
+
+## Features
+
+[~] Feature 01.1: namespaced planned thing
+    Notes: Gate-4 (2026-07-05): planned, awaiting build.
+EOF
+bash "$HERE/state-status.sh" --check-buildable "Feature 01.1" "$N" >/dev/null 2>&1 \
+  && ok "namespaced: planned feature is BUILDABLE" || bad "namespaced: planned feature is BUILDABLE"
+NDIGEST="$(bash "$HERE/state-status.sh" "$N")"
+grep -q '.project/robin/milestones/01-alpha' <<< "$NDIGEST" \
+  && ok "namespaced: digest labels by relative path" || bad "namespaced: digest labels by relative path"
+grep -q 'Feature 01.1' <<< "$NDIGEST" \
+  && ok "namespaced: awaiting-build listed" || bad "namespaced: awaiting-build listed"
+# override glob still works
+CC_MILESTONE_GLOB=".project/*/milestones/*/milestone-status.txt" \
+  bash "$HERE/state-status.sh" --check-buildable "Feature 01.1" "$N" >/dev/null 2>&1 \
+  && ok "CC_MILESTONE_GLOB override resolves" || bad "CC_MILESTONE_GLOB override resolves"
+rm -rf "$N"
+
+echo "== block-heredoc-commit hook =="
+OUT="$(printf '%s' '{"tool_input":{"command":"git commit -m \"$(cat <<EOF\nx\nEOF\n)\""}}' | node "$HOOK_DIR/block-heredoc-commit.js")"
+grep -q '"permissionDecision":"deny"' <<< "$OUT" && ok "heredoc commit denied" || bad "heredoc commit denied"
+OUT="$(printf '%s' '{"tool_input":{"command":"git commit -F .git/msg"}}' | node "$HOOK_DIR/block-heredoc-commit.js")"
+[[ -z "$OUT" ]] && ok "file-based commit allowed" || bad "file-based commit allowed"
+OUT="$(printf '%s' '{"tool_input":{"command":"cat <<EOF\nhello\nEOF"}}' | node "$HOOK_DIR/block-heredoc-commit.js")"
+[[ -z "$OUT" ]] && ok "non-commit heredoc allowed" || bad "non-commit heredoc allowed"
+
+echo "== run-quiet =="
+bash "$HERE/run-quiet.sh" true >/dev/null 2>&1 && ok "success path rc=0" || bad "success path rc=0"
+bash "$HERE/run-quiet.sh" bash -c 'echo "Error: boom"; exit 3' >/dev/null 2>&1
+[[ $? -eq 3 ]] && ok "failure rc preserved" || bad "failure rc preserved"
+
+echo "== branch-sync base-branch resolution =="
+# Mirror the resolver: env → .cc-base-branch → remote HEAD. Test the first two precedences
+# in a throwaway git repo (no remote needed; we never reach the destructive reset).
+BR_D="$(mktemp -d "${TMPDIR:-/tmp}/check-bsync.XXXXXX")"
+( cd "$BR_D" && git init -q && git checkout -q -b feat-x 2>/dev/null )
+printf 'integration-base\n' > "$BR_D/.cc-base-branch"
+RESOLVED="$(cd "$BR_D" && TOP="$(git rev-parse --show-toplevel)"
+  if [[ -n "${CC_BASE_BRANCH:-}" ]]; then echo "$CC_BASE_BRANCH"
+  elif [[ -f "$TOP/.cc-base-branch" ]]; then head -n1 "$TOP/.cc-base-branch" | tr -d '[:space:]'
+  fi)"
+[[ "$RESOLVED" == "integration-base" ]] && ok ".cc-base-branch resolves to integration-base" || bad ".cc-base-branch resolves to integration-base (got '$RESOLVED')"
+RESOLVED_ENV="$(cd "$BR_D" && CC_BASE_BRANCH=override bash -c 'echo "${CC_BASE_BRANCH}"')"
+[[ "$RESOLVED_ENV" == "override" ]] && ok "CC_BASE_BRANCH env wins" || bad "CC_BASE_BRANCH env wins"
+# branch-sync must refuse when feature branch == base (guard), not attempt a reset.
+( cd "$BR_D" && git checkout -q -b integration-base 2>/dev/null; bash "$HERE/branch-sync.sh" integration-base >/dev/null 2>&1 )
+[[ $? -ne 0 ]] && ok "refuses reset when on integration branch" || bad "refuses reset when on integration branch"
+rm -rf "$BR_D"
+
+echo
+echo "RESULT: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/scripts/claude-toolkit/check.sh
+++ b/scripts/claude-toolkit/check.sh
@@ -122,6 +122,31 @@ OUT="$(printf '%s' '{"tool_input":{"command":"git commit -F .git/msg"}}' | node 
 [[ -z "$OUT" ]] && ok "file-based commit allowed" || bad "file-based commit allowed"
 OUT="$(printf '%s' '{"tool_input":{"command":"cat <<EOF\nhello\nEOF"}}' | node "$HOOK_DIR/block-heredoc-commit.js")"
 [[ -z "$OUT" ]] && ok "non-commit heredoc allowed" || bad "non-commit heredoc allowed"
+# delimiter variants: quoted, dash-suffixed, spaced, backslash-escaped, digit-leading.
+# jq builds the JSON so shell quoting never distorts the probe.
+HEREDOC_DELIMS=("<<'EOF'" '<<"EOF"' '<<-EOF' '<< EOF' '<<\EOF' '<<1EOF')
+for D in "${HEREDOC_DELIMS[@]}"; do
+  OUT="$(jq -nc --arg c "git commit -F - ${D}"$'\nmsg\nEOF' '{tool_input:{command:$c}}' \
+    | node "$HOOK_DIR/block-heredoc-commit.js")"
+  grep -q '"permissionDecision":"deny"' <<< "$OUT" && ok "heredoc delimiter denied: $D" || bad "heredoc delimiter denied: $D"
+done
+# left-shift arithmetic in a commit command must NOT be mistaken for a heredoc
+OUT="$(jq -nc --arg c 'git commit -F .git/msg && n=$((1 << 2))' '{tool_input:{command:$c}}' \
+  | node "$HOOK_DIR/block-heredoc-commit.js")"
+[[ -z "$OUT" ]] && ok "left-shift arithmetic allowed" || bad "left-shift arithmetic allowed"
+# herestring is not a heredoc
+OUT="$(jq -nc --arg c 'git commit -F /dev/stdin <<< "msg"' '{tool_input:{command:$c}}' \
+  | node "$HOOK_DIR/block-heredoc-commit.js")"
+[[ -z "$OUT" ]] && ok "herestring allowed" || bad "herestring allowed"
+
+echo "== codex-review files mode preflight =="
+CR_D="$(mktemp -d "${TMPDIR:-/tmp}/check-codex.XXXXXX")"
+bash "$HERE/codex-review.sh" "$CR_D/does-not-exist.txt" >/dev/null 2>&1
+[[ $? -eq 2 ]] && ok "missing file rejected (exit 2)" || bad "missing file rejected (exit 2)"
+printf '\x00\x01\x02binary\x00' > "$CR_D/blob.bin"
+bash "$HERE/codex-review.sh" "$CR_D/blob.bin" >/dev/null 2>&1
+[[ $? -eq 2 ]] && ok "binary file rejected (exit 2)" || bad "binary file rejected (exit 2)"
+rm -rf "$CR_D"
 
 echo "== run-quiet =="
 bash "$HERE/run-quiet.sh" true >/dev/null 2>&1 && ok "success path rc=0" || bad "success path rc=0"

--- a/scripts/claude-toolkit/codex-review.sh
+++ b/scripts/claude-toolkit/codex-review.sh
@@ -69,6 +69,20 @@ case "$MODE" in
   files)
     : > "$CTX"
     for f in "${FILES[@]}"; do
+      # Fail fast: a silently-omitted file yields a review of incomplete context,
+      # which can return VERDICT: PASS on code that was never actually read.
+      if [[ ! -f "$f" ]]; then
+        echo "codex-review: no such file: $f" >&2
+        exit 2
+      fi
+      if [[ ! -r "$f" ]]; then
+        echo "codex-review: file is not readable: $f" >&2
+        exit 2
+      fi
+      if ! grep -Iq . "$f" 2>/dev/null; then
+        echo "codex-review: refusing to review binary file: $f" >&2
+        exit 2
+      fi
       printf '\n===== %s =====\n' "$f" >> "$CTX"
       cat "$f" >> "$CTX"
     done

--- a/scripts/claude-toolkit/codex-review.sh
+++ b/scripts/claude-toolkit/codex-review.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# codex-review.sh — blocking Codex review with timeout, safe stdin, read-only sandbox,
+# and a machine-readable VERDICT line.
+#
+# Replaces the manually retyped pattern:
+#   "Task a codex agent to review... codex exec [PROMPT] via stdin, no backticks"
+# and fixes the recurring failure modes: hangs (stdin left open), no timeout,
+# writable sandbox, verdicts inferred from tail-streamed output.
+#
+# Usage:
+#   codex-review.sh [-t SECONDS] [-p "extra instructions"] MODE
+#   MODE:
+#     --diff            review unstaged+staged changes vs HEAD (default)
+#     --staged          review staged changes only
+#     --commits A..B    review a commit range (git log -p)
+#     FILE [FILE...]    review specific files
+#
+# Output: findings on stdout, final line "VERDICT: PASS" or "VERDICT: FAIL".
+# Exit codes: 0 = PASS, 1 = FAIL (or missing verdict), 2 = codex error/timeout.
+set -uo pipefail
+
+TIMEOUT_SECS=300
+EXTRA=""
+MODE="diff"
+RANGE=""
+FILES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -t) TIMEOUT_SECS="$2"; shift 2 ;;
+    -p) EXTRA="$2"; shift 2 ;;
+    --diff) MODE="diff"; shift ;;
+    --staged) MODE="staged"; shift ;;
+    --commits) MODE="commits"; RANGE="$2"; shift 2 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) MODE="files"; FILES+=("$1"); shift ;;
+  esac
+done
+
+for DEP in git jq codex; do
+  command -v "$DEP" >/dev/null 2>&1 || { echo "codex-review: missing dependency: $DEP" >&2; exit 2; }
+done
+
+# macOS: coreutils installs gtimeout; gnubin may also provide timeout.
+TIMEOUT_BIN="$(command -v timeout || command -v gtimeout || true)"
+if [[ -z "$TIMEOUT_BIN" ]]; then
+  echo "codex-review: need GNU timeout (brew install coreutils)" >&2
+  exit 2
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/codex-review.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+CTX="$WORK/context.txt"
+
+case "$MODE" in
+  diff)
+    git diff --no-ext-diff --no-color HEAD > "$CTX"
+    # `git diff` excludes untracked files — append them so brand-new files are
+    # actually reviewed instead of silently omitted.
+    while IFS= read -r f; do
+      [[ -f "$f" ]] || continue
+      grep -Iq . "$f" 2>/dev/null || continue   # skip binaries
+      printf '\n===== NEW (untracked): %s =====\n' "$f" >> "$CTX"
+      cat "$f" >> "$CTX"
+    done < <(git ls-files --others --exclude-standard)
+    ;;
+  staged)  git diff --no-ext-diff --no-color --staged > "$CTX" ;;
+  commits) git log --patch --no-color "$RANGE" > "$CTX" ;;
+  files)
+    : > "$CTX"
+    for f in "${FILES[@]}"; do
+      printf '\n===== %s =====\n' "$f" >> "$CTX"
+      cat "$f" >> "$CTX"
+    done
+    ;;
+esac
+
+if [[ ! -s "$CTX" ]]; then
+  echo "codex-review: empty context — nothing to review" >&2
+  exit 2
+fi
+
+CTX_BYTES="$(wc -c < "$CTX")"
+if (( CTX_BYTES > 400000 )); then
+  echo "codex-review: warning — context is $((CTX_BYTES / 1024))KB; consider narrowing scope" >&2
+fi
+
+read -r -d '' PROMPT <<'EOF' || true
+You are a rigorous code reviewer. Review the context below (a diff, commit range, or files).
+Report only verified findings, one line each, format:
+  P1|P2|P3 file:line — problem — fix
+P1 = breaks correctness/security, P2 = significant defect, P3 = minor.
+No praise, no restating the diff. If a finding is speculative, mark it (unverified).
+The FINAL line of your reply must be exactly "VERDICT: PASS" (zero P1/P2 findings)
+or "VERDICT: FAIL" (one or more P1/P2 findings).
+EOF
+
+EVENTS="$WORK/events.jsonl"
+ERRLOG="$WORK/stderr.log"
+
+# Prompt + context piped on stdin ("-"); stdin is consumed and closed — no hang.
+# -s read-only: review must never run with a writable sandbox.
+{ printf '%s\n\n%s\n\n--- CONTEXT ---\n' "$PROMPT" "$EXTRA"; cat "$CTX"; } | \
+  "$TIMEOUT_BIN" --kill-after=10 "$TIMEOUT_SECS" \
+  codex exec --json -s read-only --skip-git-repo-check - \
+  > "$EVENTS" 2> "$ERRLOG"
+RC=$?
+
+if [[ $RC -eq 124 || $RC -eq 137 ]]; then
+  echo "codex-review: TIMEOUT after ${TIMEOUT_SECS}s (process killed)" >&2
+  tail -n 5 "$ERRLOG" >&2 || true
+  exit 2
+elif [[ $RC -ne 0 ]]; then
+  echo "codex-review: codex exec failed rc=$RC" >&2
+  tail -n 20 "$ERRLOG" >&2 || true
+  exit 2
+fi
+
+# Same event schema the triad-refine run-codex.sh parses (.item.text of agent messages).
+TEXT="$(jq -rs '[.[] | select(.item.type? == "agent_message") | .item.text] | last // empty' "$EVENTS")"
+if [[ -z "$TEXT" ]]; then
+  echo "codex-review: no agent message found in codex output" >&2
+  tail -n 5 "$ERRLOG" >&2 || true
+  exit 2
+fi
+
+printf '%s\n' "$TEXT"
+
+if grep -q '^VERDICT: PASS[[:space:]]*$' <<< "$TEXT"; then
+  exit 0
+elif grep -q '^VERDICT: FAIL[[:space:]]*$' <<< "$TEXT"; then
+  exit 1
+else
+  echo "codex-review: missing VERDICT line — treating as FAIL" >&2
+  exit 1
+fi

--- a/scripts/claude-toolkit/gcommit
+++ b/scripts/claude-toolkit/gcommit
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# gcommit — commit via message file (git commit -F). Never heredocs, never multi-line -m.
+# Ends the recurring heredoc-quoting commit failures.
+#
+# Usage:
+#   gcommit "subject line"                      # subject-only commit
+#   gcommit path/to/message.txt                 # message from an existing file
+#   printf 'subject\n\nbody...\n' | gcommit     # full message on stdin
+set -euo pipefail
+
+GIT_DIR="$(git rev-parse --git-dir)"
+MSG_FILE="$GIT_DIR/CLAUDE_COMMIT_MSG"
+
+if [[ $# -ge 1 && -f "$1" ]]; then
+  cp "$1" "$MSG_FILE"
+elif [[ $# -ge 1 ]]; then
+  printf '%s\n' "$*" > "$MSG_FILE"
+elif [[ ! -t 0 ]]; then
+  cat > "$MSG_FILE"
+else
+  echo "usage: gcommit \"subject\" | gcommit msgfile | printf 'msg' | gcommit" >&2
+  exit 64
+fi
+
+if [[ ! -s "$MSG_FILE" ]]; then
+  echo "gcommit: empty commit message" >&2
+  exit 1
+fi
+
+SUBJECT="$(head -n 1 "$MSG_FILE")"
+if [[ -z "${SUBJECT// /}" ]]; then
+  echo "gcommit: first line (subject) is empty" >&2
+  exit 1
+fi
+
+echo "gcommit: $SUBJECT"
+git commit -F "$MSG_FILE"

--- a/scripts/claude-toolkit/hooks/block-heredoc-commit.js
+++ b/scripts/claude-toolkit/hooks/block-heredoc-commit.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// PreToolUse hook (matcher: Bash) — deny `git commit` commands that use heredocs
+// or multi-line -m arguments, the root cause of the recurring commit failures.
+// Redirects the model to the file-based flow: git commit -F <file> (or `gcommit`).
+//
+// Install in .claude/settings.json (project-relative, matches the checked-in config):
+//   "hooks": { "PreToolUse": [ { "matcher": "Bash", "hooks": [
+//     { "type": "command", "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-heredoc-commit.js\"", "timeout": 5 }
+//   ] } ] }
+
+let input = '';
+process.stdin.on('data', (d) => (input += d));
+process.stdin.on('end', () => {
+  let cmd = '';
+  try {
+    const payload = JSON.parse(input);
+    cmd = (payload.tool_input && payload.tool_input.command) || '';
+  } catch {
+    process.exit(0); // unparseable — do not block
+  }
+
+  const isCommit = /git\s+([^\n;|&]*\s)?commit/.test(cmd);
+  if (!isCommit) process.exit(0);
+
+  const usesHeredoc = /<<-?\s*['"]?[A-Za-z_]+/.test(cmd);
+  const multilineDashM = /(^|\s)-m\b/.test(cmd) && cmd.includes('\n');
+
+  if (usesHeredoc || multilineDashM) {
+    console.log(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason:
+            'Heredoc / multi-line -m commit messages break quoting (recurring failure). ' +
+            'Write the message to a file and run: git commit -F <file> ' +
+            '(or use the gcommit helper).',
+        },
+      })
+    );
+  }
+  process.exit(0);
+});

--- a/scripts/claude-toolkit/hooks/block-heredoc-commit.js
+++ b/scripts/claude-toolkit/hooks/block-heredoc-commit.js
@@ -22,7 +22,11 @@ process.stdin.on('end', () => {
   const isCommit = /git\s+([^\n;|&]*\s)?commit/.test(cmd);
   if (!isCommit) process.exit(0);
 
-  const usesHeredoc = /<<-?\s*['"]?[A-Za-z_]+/.test(cmd);
+  // Covers `<<EOF`, `<<-EOF`, `<< EOF`, `<<'EOF'`, `<<"EOF"`, `<<\EOF` and
+  // digit-leading delimiters like `<<1EOF`. Excludes `<<<` (herestring) and
+  // bare-numeric `<< 2` (left-shift) so arithmetic in a commit command is not
+  // mistaken for a heredoc.
+  const usesHeredoc = /(?<!<)<<(?!<)-?\s*\\?['"]?(?:[A-Za-z_]|[0-9]+[A-Za-z_])/.test(cmd);
   const multilineDashM = /(^|\s)-m\b/.test(cmd) && cmd.includes('\n');
 
   if (usesHeredoc || multilineDashM) {

--- a/scripts/claude-toolkit/hooks/lint-md-on-edit.js
+++ b/scripts/claude-toolkit/hooks/lint-md-on-edit.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+// PostToolUse hook (matcher: Edit|Write) — auto-fix markdown on the edited file.
+// Runs `markdownlint-cli2 --fix` only when the touched file is .md, so edit-time
+// formatting matches the repo's pre-commit markdownlint hook (fewer autofix cycles).
+// Non-blocking and silent: never fails a tool call.
+let input = '';
+process.stdin.on('data', (d) => (input += d));
+process.stdin.on('end', () => {
+  let fp = '';
+  try {
+    const p = JSON.parse(input);
+    fp = (p.tool_input && (p.tool_input.file_path || p.tool_input.path)) || '';
+  } catch {
+    process.exit(0);
+  }
+  if (!/\.(md|markdown)$/i.test(fp)) process.exit(0);
+  // Resolve to an absolute path so a leading '-' can never be parsed as a flag
+  // by markdownlint-cli2. (Edit/Write paths are already absolute; this is belt-and-suspenders.)
+  const abs = require('path').resolve(fp);
+  try {
+    require('child_process').spawnSync('markdownlint-cli2', ['--fix', abs], { stdio: 'ignore' });
+  } catch {
+    /* tool missing — do not block the edit */
+  }
+  process.exit(0);
+});

--- a/scripts/claude-toolkit/install.sh
+++ b/scripts/claude-toolkit/install.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# scripts/claude-toolkit/install.sh
+# Idempotent installer for the Claude Code toolkit (scripts + hooks).
+#
+# Installs into a target Claude Code project:
+#   - Helper scripts       -> <target>/.claude/scripts/
+#   - Tool hooks (node)    -> <target>/.claude/hooks/
+#   - Hook entries         -> <target>/.claude/settings.json  (jq-merged, versioned markers)
+#   - Git/review guidance  -> <target>/CLAUDE.md              (sentinel-guarded)
+#   - Base branch pin      -> <target>/.cc-base-branch        (only with --base-branch, only if absent)
+#
+# Usage:
+#   bash scripts/claude-toolkit/install.sh [--base-branch NAME] <target-repo-path>
+#
+# Prerequisites (hard): jq, node  — the hooks are node scripts, so node is a hard
+#   prereq here (a deliberate extension of the defensive-protocol installer idiom).
+# Optional runtime deps (warn only): markdownlint-cli2 (lint-md-on-edit hook),
+#   codex + GNU timeout (codex-review.sh).
+# Idempotent: re-running produces no changes. Existing UNMARKED entries that
+#   already invoke these hook scripts are migrated to the marker format instead
+#   of being duplicated.
+# Never sets the executable bit — invoke everything via `bash <script>`.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ── Prerequisites ─────────────────────────────────────────────────────────────
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'ERROR: jq is required but not found in PATH.\n' >&2
+  printf '       macOS:  brew install jq\n' >&2
+  printf '       Debian: sudo apt-get install jq\n' >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  printf 'ERROR: node is required but not found in PATH (the hooks are node scripts).\n' >&2
+  printf '       macOS:  brew install node\n' >&2
+  printf '       Other:  https://nodejs.org/\n' >&2
+  exit 1
+fi
+
+command -v markdownlint-cli2 >/dev/null 2>&1 \
+  || printf 'WARN: markdownlint-cli2 not found — the lint-md-on-edit hook will be a silent no-op until installed (npm i -g markdownlint-cli2).\n' >&2
+command -v codex >/dev/null 2>&1 \
+  || printf 'WARN: codex CLI not found — codex-review.sh will not run until installed.\n' >&2
+
+# ── Arguments ─────────────────────────────────────────────────────────────────
+
+BASE_BRANCH=""
+TARGET_INPUT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-branch)
+      [[ $# -ge 2 ]] || { printf 'ERROR: --base-branch requires a value.\n' >&2; exit 1; }
+      BASE_BRANCH="$2"; shift 2 ;;
+    -*)
+      printf 'ERROR: Unknown option: %s\n' "$1" >&2
+      printf 'Usage: bash scripts/claude-toolkit/install.sh [--base-branch NAME] <target-repo-path>\n' >&2
+      exit 1 ;;
+    *)
+      if [[ -n "$TARGET_INPUT" ]]; then
+        printf 'Usage: bash scripts/claude-toolkit/install.sh [--base-branch NAME] <target-repo-path>\n' >&2
+        exit 1
+      fi
+      TARGET_INPUT="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$TARGET_INPUT" ]]; then
+  printf 'Usage: bash scripts/claude-toolkit/install.sh [--base-branch NAME] <target-repo-path>\n' >&2
+  exit 1
+fi
+if [[ ! -d "$TARGET_INPUT" ]]; then
+  printf 'ERROR: Target is not a directory: %s\n' "$TARGET_INPUT" >&2
+  exit 1
+fi
+
+TARGET="$(cd "$TARGET_INPUT" && pwd)"
+SCRIPTS_DST="$TARGET/.claude/scripts"
+HOOKS_DST="$TARGET/.claude/hooks"
+SETTINGS="$TARGET/.claude/settings.json"
+CLAUDE_MD="$TARGET/CLAUDE.md"
+
+printf '==> Installing Claude Code toolkit into %s\n' "$TARGET"
+
+# ── 1. Directories ────────────────────────────────────────────────────────────
+
+mkdir -p "$SCRIPTS_DST" "$HOOKS_DST"
+printf '==> Dirs:  .claude/scripts/  .claude/hooks/\n'
+
+# ── 2. File copy (scripts + hooks) ───────────────────────────────────────────
+
+_copy_file() {
+  local src="$1" dst="$2" label="$3"
+  if [[ ! -f "$src" ]]; then
+    printf 'ERROR: Source file missing: %s\n' "$src" >&2
+    exit 1
+  fi
+  if [[ ! -f "$dst" ]]; then
+    cp "$src" "$dst"
+    printf '==> %-14s  added     %s\n' "$label" "$(basename "$dst")"
+  elif cmp -s "$src" "$dst"; then
+    printf '==> %-14s  unchanged %s\n' "$label" "$(basename "$dst")"
+  else
+    cp "$src" "$dst"
+    printf '==> %-14s  updated   %s\n' "$label" "$(basename "$dst")"
+  fi
+}
+
+_copy_file "$SCRIPT_DIR/gcommit"         "$SCRIPTS_DST/gcommit"         "Script"
+_copy_file "$SCRIPT_DIR/branch-sync.sh"  "$SCRIPTS_DST/branch-sync.sh"  "Script"
+_copy_file "$SCRIPT_DIR/codex-review.sh" "$SCRIPTS_DST/codex-review.sh" "Script"
+_copy_file "$SCRIPT_DIR/run-quiet.sh"    "$SCRIPTS_DST/run-quiet.sh"    "Script"
+_copy_file "$SCRIPT_DIR/state-status.sh" "$SCRIPTS_DST/state-status.sh" "Script"
+_copy_file "$SCRIPT_DIR/check.sh"        "$SCRIPTS_DST/check.sh"        "Script"
+
+_copy_file "$SCRIPT_DIR/hooks/block-heredoc-commit.js" "$HOOKS_DST/block-heredoc-commit.js" "Hook"
+_copy_file "$SCRIPT_DIR/hooks/lint-md-on-edit.js"      "$HOOKS_DST/lint-md-on-edit.js"      "Hook"
+
+# ── 3. settings.json — validate / create ─────────────────────────────────────
+
+if [[ ! -f "$SETTINGS" ]]; then
+  printf '{}' > "$SETTINGS"
+  printf '==> settings.json: created\n'
+elif ! jq empty "$SETTINGS" >/dev/null 2>&1; then
+  printf 'ERROR: %s is not valid JSON.\n' "$SETTINGS" >&2
+  printf '       Fix or remove the file before re-running.\n' >&2
+  exit 1
+else
+  printf '==> settings.json: valid JSON\n'
+fi
+
+# ── 4. Merge hook entries (idempotent, versioned markers) ─────────────────────
+# Each hook command embeds a marker as its first line; the idempotency check
+# scans the full settings.json tree for that marker. Additionally, entries that
+# invoke the same hook SCRIPT without a marker (hand-wired installs that predate
+# this installer) are migrated: the old entry is removed and the marker-bearing
+# entry added, so re-installation never duplicates a hook.
+
+_hook_present() {
+  local marker="$1"
+  jq -e --arg m "$marker" \
+    '[.. | objects | .command? // empty | select(type == "string" and contains($m))] | length > 0' \
+    "$SETTINGS" >/dev/null 2>&1
+}
+
+_unmarked_present() {
+  local script_name="$1" marker="$2"
+  jq -e --arg s "$script_name" --arg m "$marker" \
+    '[.. | objects | .command? // empty
+      | select(type == "string" and contains($s) and (contains($m) | not))] | length > 0' \
+    "$SETTINGS" >/dev/null 2>&1
+}
+
+_merge_hook() {
+  local marker="$1" event="$2" matcher="$3" cmd="$4" timeout="$5" status_msg="$6" script_name="$7" label="$8"
+
+  if _hook_present "$marker"; then
+    printf '==> Hook  already installed: %s\n' "$label"
+    return
+  fi
+
+  local TMP
+  TMP="$(mktemp "$TARGET/.claude/settings.json.XXXXXX")"
+  trap 'rm -f "$TMP"' EXIT
+
+  if _unmarked_present "$script_name" "$marker"; then
+    # Migrate: drop hand-wired entries that invoke the same hook script.
+    jq --arg s "$script_name" '
+      if .hooks then
+        .hooks |= with_entries(
+          .value |= [ .[]
+            | .hooks = ((.hooks // []) | map(select((.command // "" | contains($s)) | not)))
+            | select((.hooks | length) > 0) ]
+        )
+      else . end
+    ' "$SETTINGS" > "$TMP"
+    mv "$TMP" "$SETTINGS"
+    TMP="$(mktemp "$TARGET/.claude/settings.json.XXXXXX")"
+    printf '==> Hook  migrated unmarked entry: %s\n' "$label"
+  fi
+
+  jq --arg event "$event" --arg matcher "$matcher" --arg cmd "$cmd" \
+     --argjson timeout "$timeout" --arg msg "$status_msg" '
+    .hooks              = (.hooks // {}) |
+    .hooks[$event]      = (.hooks[$event] // []) |
+    .hooks[$event]     += [{ matcher: $matcher,
+                             hooks: [{ type: "command", command: $cmd,
+                                       timeout: $timeout, statusMessage: $msg }] }]
+  ' "$SETTINGS" > "$TMP"
+  mv "$TMP" "$SETTINGS"
+  trap - EXIT
+
+  printf '==> Hook  added: %s\n' "$label"
+}
+
+# PreToolUse / Bash: deny heredoc & multi-line -m commits, steer to gcommit
+_merge_hook \
+  "# cc-toolkit-heredoc-block v1" \
+  "PreToolUse" "Bash" \
+  '# cc-toolkit-heredoc-block v1
+node "$CLAUDE_PROJECT_DIR/.claude/hooks/block-heredoc-commit.js"' \
+  5 "Checking commit style..." \
+  "block-heredoc-commit.js" \
+  "block-heredoc-commit (PreToolUse/Bash)"
+
+# PostToolUse / Edit|Write: markdownlint --fix on edited markdown
+_merge_hook \
+  "# cc-toolkit-lint-md v1" \
+  "PostToolUse" "Edit|Write" \
+  '# cc-toolkit-lint-md v1
+node "$CLAUDE_PROJECT_DIR/.claude/hooks/lint-md-on-edit.js"' \
+  15 "Formatting markdown..." \
+  "lint-md-on-edit.js" \
+  "lint-md-on-edit (PostToolUse/Edit|Write)"
+
+# ── 5. CLAUDE.md — toolkit guidance sentinel block ────────────────────────────
+
+SENTINEL_BEGIN='<!-- BEGIN CLAUDE-TOOLKIT -->'
+SENTINEL_END='<!-- END CLAUDE-TOOLKIT -->'
+
+_claude_md_block() {
+  cat << 'BLOCK_EOF'
+<!-- BEGIN CLAUDE-TOOLKIT -->
+## Git / Version Control (claude-toolkit)
+
+- Commit via `bash .claude/scripts/gcommit "<subject>"` (or pipe a full message on
+  stdin). Never use a heredoc or a multi-line `-m` — the `block-heredoc-commit`
+  PreToolUse hook denies those and steers to gcommit.
+- The integration base branch resolves in this order: `$CC_BASE_BRANCH` env var →
+  `.cc-base-branch` file at the repo root → the origin HEAD branch.
+- After a feature branch is squash-merged, run
+  `bash .claude/scripts/branch-sync.sh` to reset it onto the base branch.
+
+## Code review & Claude tooling (claude-toolkit)
+
+- Codex reviews go through `bash .claude/scripts/codex-review.sh` (`--diff`,
+  `--staged`, `--commits A..B`, or explicit files) — never hand-roll `codex exec`.
+  Exit 0 = PASS, 1 = FAIL, 2 = review failed (timeout/error) — never treat 2 as PASS.
+- Markdown edits are auto-fixed by the `lint-md-on-edit` PostToolUse hook
+  (requires `markdownlint-cli2` on PATH; silent no-op otherwise).
+- `bash .claude/scripts/run-quiet.sh <cmd>` runs a noisy command and prints only
+  a summary; `bash .claude/scripts/state-status.sh` digests gated-workflow state.
+- Self-test the toolkit with `bash .claude/scripts/check.sh`.
+<!-- END CLAUDE-TOOLKIT -->
+BLOCK_EOF
+}
+
+_has_begin=0; _has_end=0
+if [[ -f "$CLAUDE_MD" ]]; then
+  grep -qF "$SENTINEL_BEGIN" "$CLAUDE_MD" && _has_begin=1
+  grep -qF "$SENTINEL_END"   "$CLAUDE_MD" && _has_end=1
+fi
+
+if [[ "$_has_begin" -ne "$_has_end" ]]; then
+  printf 'ERROR: %s has a malformed CLAUDE-TOOLKIT sentinel block (BEGIN without END or vice versa).\n' "$CLAUDE_MD" >&2
+  printf '       Repair or remove the partial block before re-running.\n' >&2
+  exit 1
+fi
+
+if [[ ! -f "$CLAUDE_MD" ]]; then
+  _claude_md_block > "$CLAUDE_MD"
+  printf '==> CLAUDE.md: created with toolkit block\n'
+elif [[ "$_has_begin" -eq 1 ]]; then
+  printf '==> CLAUDE.md: toolkit block already present\n'
+else
+  printf '\n' >> "$CLAUDE_MD"
+  _claude_md_block >> "$CLAUDE_MD"
+  printf '==> CLAUDE.md: toolkit block appended\n'
+fi
+
+# ── 6. .cc-base-branch (opt-in, never overwrites) ─────────────────────────────
+
+if [[ -n "$BASE_BRANCH" ]]; then
+  CC_FILE="$TARGET/.cc-base-branch"
+  if [[ ! -f "$CC_FILE" ]]; then
+    printf '%s\n' "$BASE_BRANCH" > "$CC_FILE"
+    printf '==> .cc-base-branch: added (%s)\n' "$BASE_BRANCH"
+  else
+    EXISTING="$(head -n1 "$CC_FILE" | tr -d '[:space:]')"
+    if [[ "$EXISTING" == "$BASE_BRANCH" ]]; then
+      printf '==> .cc-base-branch: unchanged (%s)\n' "$EXISTING"
+    else
+      printf 'WARN: .cc-base-branch already contains "%s" (requested "%s") — left unchanged.\n' \
+        "$EXISTING" "$BASE_BRANCH" >&2
+      printf '==> .cc-base-branch: unchanged (%s)\n' "$EXISTING"
+    fi
+  fi
+fi
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+
+printf '\n'
+printf '==> Claude Code toolkit installed into %s\n' "$TARGET"
+printf '==> Restart Claude Code in the target repo to pick up changes.\n'

--- a/scripts/claude-toolkit/install.sh
+++ b/scripts/claude-toolkit/install.sh
@@ -154,6 +154,31 @@ _unmarked_present() {
     "$SETTINGS" >/dev/null 2>&1
 }
 
+# Guard against a hand-edited settings.json where .hooks or .hooks[$event] is not
+# the expected type — jq would otherwise fail with an opaque "object and array
+# cannot be added" message deep inside the merge.
+_assert_hook_shape() {
+  local event="$1"
+  if ! jq -e '(.hooks // {}) | type == "object"' "$SETTINGS" >/dev/null 2>&1; then
+    printf 'ERROR: %s has a ".hooks" key that is not an object.\n' "$SETTINGS" >&2
+    printf '       Repair it (or remove the key) before re-running.\n' >&2
+    exit 1
+  fi
+  if ! jq -e --arg e "$event" '(.hooks[$e] // []) | type == "array"' "$SETTINGS" >/dev/null 2>&1; then
+    printf 'ERROR: %s has ".hooks.%s" set to a %s; an array is required.\n' \
+      "$SETTINGS" "$event" \
+      "$(jq -r --arg e "$event" '.hooks[$e] | type' "$SETTINGS" 2>/dev/null || echo 'value of unexpected type')" >&2
+    printf '       Repair it (or remove the key) before re-running.\n' >&2
+    exit 1
+  fi
+}
+
+# Temp file for in-flight settings.json rewrites. Declared at file scope so the
+# EXIT trap can still resolve it if a jq/mv step fails mid-function (a `local`
+# would be out of scope by trap time, leaking the temp file under `set -u`).
+_TMP_SETTINGS=""
+trap 'rm -f "${_TMP_SETTINGS:-}"' EXIT
+
 _merge_hook() {
   local marker="$1" event="$2" matcher="$3" cmd="$4" timeout="$5" status_msg="$6" script_name="$7" label="$8"
 
@@ -162,9 +187,11 @@ _merge_hook() {
     return
   fi
 
+  _assert_hook_shape "$event"
+
   local TMP
   TMP="$(mktemp "$TARGET/.claude/settings.json.XXXXXX")"
-  trap 'rm -f "$TMP"' EXIT
+  _TMP_SETTINGS="$TMP"
 
   if _unmarked_present "$script_name" "$marker"; then
     # Migrate: drop hand-wired entries that invoke the same hook script.
@@ -179,6 +206,7 @@ _merge_hook() {
     ' "$SETTINGS" > "$TMP"
     mv "$TMP" "$SETTINGS"
     TMP="$(mktemp "$TARGET/.claude/settings.json.XXXXXX")"
+    _TMP_SETTINGS="$TMP"
     printf '==> Hook  migrated unmarked entry: %s\n' "$label"
   fi
 
@@ -191,7 +219,7 @@ _merge_hook() {
                                        timeout: $timeout, statusMessage: $msg }] }]
   ' "$SETTINGS" > "$TMP"
   mv "$TMP" "$SETTINGS"
-  trap - EXIT
+  _TMP_SETTINGS=""
 
   printf '==> Hook  added: %s\n' "$label"
 }

--- a/scripts/claude-toolkit/install.sh
+++ b/scripts/claude-toolkit/install.sh
@@ -1,18 +1,33 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016
+# The hook commands intentionally embed a literal $CLAUDE_PROJECT_DIR: it must
+# reach settings.json unexpanded so Claude Code resolves it at hook runtime, not
+# to this installer's environment at install time.
 set -euo pipefail
 
 # scripts/claude-toolkit/install.sh
-# Idempotent installer for the Claude Code toolkit (scripts + hooks).
+# Idempotent installer for the Claude Code toolkit (scripts + hooks + project skills).
 #
 # Installs into a target Claude Code project:
 #   - Helper scripts       -> <target>/.claude/scripts/
 #   - Tool hooks (node)    -> <target>/.claude/hooks/
+#   - Gated project suite  -> <target>/.claude/skills/        (flattened — see below)
 #   - Hook entries         -> <target>/.claude/settings.json  (jq-merged, versioned markers)
 #   - Git/review guidance  -> <target>/CLAUDE.md              (sentinel-guarded)
 #   - Base branch pin      -> <target>/.cc-base-branch        (only with --base-branch, only if absent)
 #
 # Usage:
-#   bash scripts/claude-toolkit/install.sh [--base-branch NAME] <target-repo-path>
+#   bash scripts/claude-toolkit/install.sh [--base-branch NAME] [--no-skills] <target-repo-path>
+#
+# Skill layout: this library nests the suite as skills/project/<sub>/ for
+#   authoring, but Claude Code resolves a slash command from the skill
+#   directory's own name. The orchestrator invokes its sub-skills as bare
+#   commands (/build, /define, ...) and each SKILL.md declares a bare `name:`,
+#   so the sub-skills are FLATTENED on install:
+#     skills/project/SKILL.md + references/  ->  .claude/skills/project/
+#     skills/project/build/                  ->  .claude/skills/build/
+#     skills/project/define/                 ->  .claude/skills/define/   (etc.)
+#   This matches the layout proven in the source consumer repo.
 #
 # Prerequisites (hard): jq, node  — the hooks are node scripts, so node is a hard
 #   prereq here (a deliberate extension of the defensive-protocol installer idiom).
@@ -24,6 +39,10 @@ set -euo pipefail
 # Never sets the executable bit — invoke everything via `bash <script>`.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SKILLS_SRC="$REPO_ROOT/skills/project"
+# Sub-skills of the gated suite, flattened to top level on install.
+PROJECT_SUBSKILLS=(build define design milestone plan-feature spike)
 
 # ── Prerequisites ─────────────────────────────────────────────────────────────
 
@@ -48,20 +67,24 @@ command -v codex >/dev/null 2>&1 \
 
 # ── Arguments ─────────────────────────────────────────────────────────────────
 
+USAGE='Usage: bash scripts/claude-toolkit/install.sh [--base-branch NAME] [--no-skills] <target-repo-path>'
 BASE_BRANCH=""
 TARGET_INPUT=""
+WITH_SKILLS=1
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --base-branch)
       [[ $# -ge 2 ]] || { printf 'ERROR: --base-branch requires a value.\n' >&2; exit 1; }
       BASE_BRANCH="$2"; shift 2 ;;
+    --no-skills)
+      WITH_SKILLS=0; shift ;;
     -*)
       printf 'ERROR: Unknown option: %s\n' "$1" >&2
-      printf 'Usage: bash scripts/claude-toolkit/install.sh [--base-branch NAME] <target-repo-path>\n' >&2
+      printf '%s\n' "$USAGE" >&2
       exit 1 ;;
     *)
       if [[ -n "$TARGET_INPUT" ]]; then
-        printf 'Usage: bash scripts/claude-toolkit/install.sh [--base-branch NAME] <target-repo-path>\n' >&2
+        printf '%s\n' "$USAGE" >&2
         exit 1
       fi
       TARGET_INPUT="$1"; shift ;;
@@ -69,7 +92,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$TARGET_INPUT" ]]; then
-  printf 'Usage: bash scripts/claude-toolkit/install.sh [--base-branch NAME] <target-repo-path>\n' >&2
+  printf '%s\n' "$USAGE" >&2
   exit 1
 fi
 if [[ ! -d "$TARGET_INPUT" ]]; then
@@ -80,15 +103,38 @@ fi
 TARGET="$(cd "$TARGET_INPUT" && pwd)"
 SCRIPTS_DST="$TARGET/.claude/scripts"
 HOOKS_DST="$TARGET/.claude/hooks"
+SKILLS_DST="$TARGET/.claude/skills"
 SETTINGS="$TARGET/.claude/settings.json"
 CLAUDE_MD="$TARGET/CLAUDE.md"
 
+# Skills ship from the library tree, so a bundle copied out on its own cannot
+# install them. Degrade to scripts+hooks rather than failing the whole install.
+if [[ "$WITH_SKILLS" -eq 1 && ! -d "$SKILLS_SRC" ]]; then
+  printf 'WARN: %s not found — installing scripts and hooks only.\n' "$SKILLS_SRC" >&2
+  printf '      (Run this installer from a full checkout of the library to get the project skills.)\n' >&2
+  WITH_SKILLS=0
+fi
+
 printf '==> Installing Claude Code toolkit into %s\n' "$TARGET"
+
+# Temp paths cleaned on any exit. Declared at file scope (not `local`) so the
+# trap can still resolve them if a step fails mid-function — a `local` would be
+# out of scope by trap time and, under `set -u`, the trap body itself would fail
+# and leak the file. One trap, set once: a second `trap ... EXIT` would silently
+# replace this one.
+ORCH_TMP=""
+_TMP_SETTINGS=""
+trap 'rm -rf "${ORCH_TMP:-}"; rm -f "${_TMP_SETTINGS:-}"' EXIT
 
 # ── 1. Directories ────────────────────────────────────────────────────────────
 
 mkdir -p "$SCRIPTS_DST" "$HOOKS_DST"
-printf '==> Dirs:  .claude/scripts/  .claude/hooks/\n'
+if [[ "$WITH_SKILLS" -eq 1 ]]; then
+  mkdir -p "$SKILLS_DST"
+  printf '==> Dirs:  .claude/scripts/  .claude/hooks/  .claude/skills/\n'
+else
+  printf '==> Dirs:  .claude/scripts/  .claude/hooks/\n'
+fi
 
 # ── 2. File copy (scripts + hooks) ───────────────────────────────────────────
 
@@ -118,6 +164,59 @@ _copy_file "$SCRIPT_DIR/check.sh"        "$SCRIPTS_DST/check.sh"        "Script"
 
 _copy_file "$SCRIPT_DIR/hooks/block-heredoc-commit.js" "$HOOKS_DST/block-heredoc-commit.js" "Hook"
 _copy_file "$SCRIPT_DIR/hooks/lint-md-on-edit.js"      "$HOOKS_DST/lint-md-on-edit.js"      "Hook"
+
+# ── 2b. Skill copy (gated project suite, flattened) ──────────────────────────
+# Overlay copy, never a delete: files present in the target but absent upstream
+# are left alone, so a consumer's local additions survive an upgrade. A stale
+# file from an older version is therefore not pruned — remove the skill
+# directory by hand for a clean reinstall.
+
+_copy_skill_dir() {
+  local src="$1" dst="$2" name="$3"
+  if [[ ! -f "$src/SKILL.md" ]]; then
+    printf 'ERROR: Not a skill bundle (no SKILL.md): %s\n' "$src" >&2
+    exit 1
+  fi
+
+  if [[ ! -d "$dst" ]]; then
+    mkdir -p "$dst"
+    cp -R "$src/." "$dst/"
+    printf '==> %-14s  added     %s\n' "Skill" "$name"
+    return
+  fi
+
+  # Compare only the files this installer owns; extras in the target are ignored.
+  if diff -rq "$src" "$dst" 2>/dev/null | grep -qv '^Only in '; then
+    cp -R "$src/." "$dst/"
+    printf '==> %-14s  updated   %s\n' "Skill" "$name"
+  elif diff -rq "$src" "$dst" 2>/dev/null | grep -q "^Only in $src"; then
+    cp -R "$src/." "$dst/"
+    printf '==> %-14s  updated   %s\n' "Skill" "$name"
+  else
+    printf '==> %-14s  unchanged %s\n' "Skill" "$name"
+  fi
+}
+
+if [[ "$WITH_SKILLS" -eq 1 ]]; then
+  # Orchestrator: SKILL.md + its own resource dirs, WITHOUT the nested
+  # sub-skills (those are installed flattened, below).
+  ORCH_TMP="$(mktemp -d "${TMPDIR:-/tmp}/cc-toolkit-project.XXXXXX")"
+  cp -R "$SKILLS_SRC/." "$ORCH_TMP/"
+  for sub in "${PROJECT_SUBSKILLS[@]}"; do
+    rm -rf "${ORCH_TMP:?}/$sub"
+  done
+  _copy_skill_dir "$ORCH_TMP" "$SKILLS_DST/project" "project"
+  rm -rf "$ORCH_TMP"
+  ORCH_TMP=""
+
+  for sub in "${PROJECT_SUBSKILLS[@]}"; do
+    if [[ ! -d "$SKILLS_SRC/$sub" ]]; then
+      printf 'ERROR: Expected sub-skill missing from the library: %s\n' "$SKILLS_SRC/$sub" >&2
+      exit 1
+    fi
+    _copy_skill_dir "$SKILLS_SRC/$sub" "$SKILLS_DST/$sub" "$sub"
+  done
+fi
 
 # ── 3. settings.json — validate / create ─────────────────────────────────────
 
@@ -172,12 +271,6 @@ _assert_hook_shape() {
     exit 1
   fi
 }
-
-# Temp file for in-flight settings.json rewrites. Declared at file scope so the
-# EXIT trap can still resolve it if a jq/mv step fails mid-function (a `local`
-# would be out of scope by trap time, leaking the temp file under `set -u`).
-_TMP_SETTINGS=""
-trap 'rm -f "${_TMP_SETTINGS:-}"' EXIT
 
 _merge_hook() {
   local marker="$1" event="$2" matcher="$3" cmd="$4" timeout="$5" status_msg="$6" script_name="$7" label="$8"

--- a/scripts/claude-toolkit/run-quiet.sh
+++ b/scripts/claude-toolkit/run-quiet.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# run-quiet.sh — run any command; keep the full log on disk, print only what matters.
+# Purpose: stop 1,600-test suites and terraform/kubectl dumps from landing verbatim
+# in Claude's context. Exit code of the wrapped command is preserved.
+#
+# Usage: run-quiet.sh <command> [args...]
+#   e.g. run-quiet.sh npm test
+#        run-quiet.sh terraform plan -no-color
+set -uo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: run-quiet.sh <command> [args...]" >&2
+  exit 64
+fi
+
+# NOTE: BSD/macOS mktemp requires the XXXXXX at the END of the template.
+LOG="$(mktemp "${TMPDIR:-/tmp}/run-quiet.XXXXXX")"
+"$@" > "$LOG" 2>&1
+RC=$?
+
+if [[ $RC -eq 0 ]]; then
+  echo "OK rc=0: $*"
+  WARNS="$(grep -nE 'WARN|Warning|warning:|deprecat|skipped|flaky' "$LOG" | head -n 20 || true)"
+  if [[ -n "$WARNS" ]]; then
+    echo "--- warnings (first 20) ---"
+    printf '%s\n' "$WARNS"
+  fi
+  echo "--- last 5 lines ---"
+  tail -n 5 "$LOG"
+else
+  echo "FAIL rc=$RC: $*"
+  echo "--- failure matches (first 40) ---"
+  grep -nE 'FAIL|✕|✗|✘|Error:|error TS[0-9]+|AssertionError|Traceback|panic:|FATAL' "$LOG" | head -n 40
+  echo "--- last 40 lines ---"
+  tail -n 40 "$LOG"
+  echo "--- full log: $LOG ---"
+fi
+exit $RC

--- a/scripts/claude-toolkit/state-status.sh
+++ b/scripts/claude-toolkit/state-status.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# state-status.sh — compact digest of the gated-workflow state files, plus a
+# buildable-precondition gate. Replaces the "read ALL state files fresh every
+# invocation" pattern: skills read this ~15-line digest instead of 5 full documents.
+#
+# Usage:
+#   state-status.sh [repo-root]                 # digest (default: cwd)
+#   state-status.sh --check-buildable SLUG [repo-root]   # exit 0 iff SLUG buildable
+#
+# Milestone-status files are discovered across BOTH known skill-suite layouts:
+#   flat layout        : <root>/milestones/<NN>-<name>/milestone-status.txt
+#   namespaced layout  : <root>/.project/<slug>/milestones/<NN>-<name>/milestone-status.txt
+#                        (the /project skill suite)
+# Override with CC_MILESTONE_GLOB (space-separated globs, evaluated from <root>).
+#
+# Schema:
+#   progress.txt          — "## Gates" / "## Milestones" sections; entries start [x]/[~]/[ ]
+#   milestone-status.txt  — feature headers "^[~] Feature NN.M: name" + indented note lines;
+#                           Gate-4 approval note contains the phrase "planned, awaiting build".
+# A feature is buildable iff its header is [~] AND its block contains that phrase.
+# Slugs are matched as fixed strings (never as regexes).
+set -euo pipefail
+
+CHECK=""
+if [[ "${1:-}" == "--check-buildable" ]]; then
+  CHECK="${2:?usage: state-status.sh --check-buildable SLUG}"
+  ROOT="${3:-.}"
+else
+  ROOT="${1:-.}"
+fi
+
+P="$ROOT/progress.txt"
+[[ -f "$P" ]] || { echo "state-status: no progress.txt at $ROOT" >&2; exit 1; }
+
+# Collect milestone-status.txt files across supported layouts (or the override glob).
+# Prints one path per line; nothing if none exist.
+collect_ms_files() {
+  local globs
+  if [[ -n "${CC_MILESTONE_GLOB:-}" ]]; then
+    globs="$CC_MILESTONE_GLOB"
+  else
+    globs="milestones/*/milestone-status.txt .project/*/milestones/*/milestone-status.txt"
+  fi
+  local g f
+  for g in $globs; do
+    for f in "$ROOT"/$g; do
+      [[ -f "$f" ]] && printf '%s\n' "$f"
+    done
+  done
+}
+
+# Label a milestone-status file by its path relative to root (unambiguous across layouts).
+ms_label() { local d; d="$(dirname "$1")"; printf '%s' "${d#"$ROOT"/}"; }
+
+if [[ -n "$CHECK" ]]; then
+  while IFS= read -r MS; do
+    [[ -n "$MS" ]] || continue
+    # Block scan: a [~] feature header containing the slug (fixed-string),
+    # then require "planned, awaiting build" inside that feature's block.
+    if awk -v slug="$CHECK" '
+        /^\[/ { inblk = ($0 ~ /^\[~\]/ && index($0, slug) > 0) }
+        inblk && /planned, awaiting build/ { found = 1; exit }
+        END { exit found ? 0 : 1 }
+      ' "$MS"; then
+      echo "BUILDABLE: $CHECK ($(ms_label "$MS"))"
+      exit 0
+    fi
+  done < <(collect_ms_files)
+  echo "NOT BUILDABLE: '$CHECK' has no [~] feature entry with a 'planned, awaiting build' note — run the planning gate first." >&2
+  exit 1
+fi
+
+echo "== Gates =="
+sed -n '/^## Gates/,/^## /p' "$P" | grep -E '^\[' || echo "(none recorded)"
+
+echo "== Milestones =="
+sed -n '/^## Milestones/,/^## /p' "$P" | grep -E '^\[' || echo "(none recorded)"
+
+while IFS= read -r MS; do
+  [[ -n "$MS" ]] || continue
+  echo "== $(ms_label "$MS") =="
+  grep -E '^\[|^[[:space:]]*Plan:|^[[:space:]]*Sub-features:|^[[:space:]]*Notes:' "$MS" || true
+done < <(collect_ms_files)
+
+echo "== Awaiting build =="
+AWAITING="$(
+  while IFS= read -r MS; do
+    [[ -n "$MS" ]] || continue
+    awk -v ms="$(ms_label "$MS")" '
+      /^\[~\] Feature/ {
+        hdr = $0; inblk = 1; printed = 0
+        if ($0 ~ /planned, awaiting build/) { print ms ": " hdr; printed = 1 }
+        next
+      }
+      /^\[/ { inblk = 0 }
+      inblk && /planned, awaiting build/ && !printed { print ms ": " hdr; printed = 1 }
+    ' "$MS"
+  done < <(collect_ms_files)
+)"
+if [[ -n "$AWAITING" ]]; then printf '%s\n' "$AWAITING"; else echo "(none)"; fi

--- a/skills/create-prd/SKILL.md
+++ b/skills/create-prd/SKILL.md
@@ -27,6 +27,14 @@ Create a complete project foundation through a structured interview process. Pro
 - Working directory is the project root (or subdirectory where the project will live)
 - Check whether any of the three output files exist (`prd.md`, `docs/ARCHITECTURE_AND_DESIGN.md`,
   `progress.txt`) — confirm with the user before overwriting any that are present
+- **Coexistence with `/project` (schema guard).** `/create-prd` writes a *light* `progress.txt`
+  (inline `[ ] Feature X.Y` lines) and routes to `/start-feature`. `/project` owns a *gated*
+  `progress.txt` (`## Gates` / `## Milestones` sections, with milestones under `.project/<slug>/`).
+  The two schemas are incompatible in one file. If the `progress.txt` in the working directory
+  contains `## Gates` or `## Milestones`, this repo is under `/project` management — **stop** and
+  tell the user: either continue with `/project`, or run `/create-prd` from a dedicated
+  subdirectory (its own working dir = its own `progress.txt`, no collision). Never overwrite a
+  gated `progress.txt` with the light schema.
 
 ## Step 1 — Seed the PRD
 

--- a/skills/project/SKILL.md
+++ b/skills/project/SKILL.md
@@ -40,7 +40,13 @@ skill on every subsequent invocation. Read-only after bootstrap.
 Read `progress.txt` from the project root.
 
 - If the file **does not exist**, proceed to Step 2 (Bootstrap).
-- If the file **exists**, proceed to Step 3 (Read State).
+- If the file **exists but is a *light* `progress.txt`** (inline `[ ] Feature X.Y` lines and no
+  `## Gates` / `## Milestones` sections), it is owned by `/create-prd` + `/start-feature`, not the
+  gated workflow. **Stop** and tell the user: this directory is under the light workflow — use
+  `/start-feature` here, or run `/project` from a directory with no light `progress.txt`. Do not
+  parse it as gated state and do not overwrite it.
+- If the file **exists** with the gated schema (`## Gates` / `## Milestones`), proceed to Step 3
+  (Read State).
 
 ## Step 2 -- Bootstrap
 

--- a/skills/project/build/references/build-execution.md
+++ b/skills/project/build/references/build-execution.md
@@ -64,11 +64,18 @@ For each unchecked `[ ]` sub-feature, in order:
 
 ### 1. Read Sub-Feature Description
 
-Read the sub-feature's description from the plan. Also read:
+The sections below are **feature-level** — identical for every sub-feature. Read
+them **once** when the loop starts, not on each iteration. Re-reading the
+architecture doc per sub-feature is wasted context:
+
 - The feature's **Approach** section for implementation strategy
 - The feature's **Interface Contracts** section for signatures and data shapes
 - The feature's **Files to Create/Modify** section for target file paths
 - `.project/<slug>/docs/ARCHITECTURE_AND_DESIGN.md` for architectural constraints
+
+On each iteration, read only **this sub-feature's** description from the plan.
+Re-open a feature-level section above only if this sub-feature specifically
+requires it (e.g. an Interface Contract you have not applied yet).
 
 ### 2. Implement the Sub-Feature
 
@@ -82,7 +89,9 @@ follow the deviation recording spec in `references/deviation-recording.md`.
 
 ### 3. Commit the Sub-Feature (D-03)
 
-Each completed sub-feature gets its own commit. Use the message format:
+Each completed sub-feature gets its own commit. Create it with
+`bash .claude/scripts/gcommit` (see **Commit Command Protocol** below) — never a
+heredoc or multi-line `-m`. Use the message format:
 
 ```
 feat(<feature-slug>): SF-N <sub-feature-name>
@@ -92,6 +101,7 @@ Where `<feature-slug>` is derived from the feature plan filename (e.g.,
 `session-management` from `session-management.md`).
 
 Example:
+
 ```
 feat(session-management): SF-2 implement data access layer
 ```
@@ -157,6 +167,7 @@ Change the feature marker from `[~]` to `[x]`. Set `Sub-features:` to `N/N
 complete`. Add `Completed: <ISO date>` to the Notes line.
 
 Before:
+
 ```
 [~] Feature 01.2: Session Management
     Plan: .project/{slug}/milestones/01-core-auth/plans/session-management.md
@@ -165,6 +176,7 @@ Before:
 ```
 
 After:
+
 ```
 [x] Feature 01.2: Session Management
     Plan: .project/{slug}/milestones/01-core-auth/plans/session-management.md
@@ -244,20 +256,44 @@ feat(<feature-slug>): SF-N <sub-feature-name>
 ```
 
 Where:
+
 - `<feature-slug>` is kebab-case derived from the feature plan filename (e.g.,
   `session-management` from `session-management.md`)
 - `N` is the sub-feature number
 - `<sub-feature-name>` is a brief description
 
 The codebase assessment refresh commit uses:
+
 ```
 docs(assessment): refresh codebase assessment for <feature-name>
 ```
 
 State file update commits on feature completion use:
+
 ```
 chore(<feature-slug>): update state files for feature completion
 ```
+
+## Commit Command Protocol (D-03)
+
+Every commit in this loop MUST be created with the file-based helper, never a
+heredoc or a multi-line `-m` (heredoc quoting failures are a recurring, avoidable
+interruption — and the repo enforces this via the `block-heredoc-commit`
+PreToolUse hook, which will deny such commits):
+
+```bash
+bash .claude/scripts/gcommit "feat(<feature-slug>): SF-N <sub-feature-name>"
+# or, for a multi-line body, write it to a file first:
+#   printf 'subject\n\nbody...\n' | bash .claude/scripts/gcommit
+```
+
+`gcommit` writes the message to a file and runs `git commit -F`, so quoting can
+never break. This applies to sub-feature, assessment-refresh, and state-file
+commits alike.
+
+The `bash .claude/scripts/...` paths assume the working directory is the repo
+root (equivalent to `$CLAUDE_PROJECT_DIR`); prefix with the repo root if running
+from a subdirectory.
 
 ## Session Continuity (D-02)
 

--- a/skills/project/build/references/codebase-refresh.md
+++ b/skills/project/build/references/codebase-refresh.md
@@ -72,7 +72,7 @@ default to `claude`.
 If the user explicitly requests a different engine, update the marker on the first
 line of `.project/<slug>/docs/codebase-assessment.md` and use the new value.
 
-**`claude` (or marker absent):** Proceed to [Claude Sub-Agent Refresh](#claude-sub-agent-refresh) below.
+**`claude` (or marker absent):** Proceed to [Claude Sub-Agent Refresh](#claude-sub-agent-refresh-build-02) below.
 
 **`gemini`:** Proceed to [Gemini Delta Scan](#gemini-delta-scan-gem-04) below.
 On any failure, fall back silently to the Claude sub-agent. Never re-prompt —
@@ -82,7 +82,7 @@ the persisted marker is the engine choice.
 
 When the engine marker is `gemini` and files have changed, run an incremental
 delta scan via Gemini. On any failure, fall back silently to
-[Claude Sub-Agent Refresh](#claude-sub-agent-refresh). Never re-prompt — the
+[Claude Sub-Agent Refresh](#claude-sub-agent-refresh-build-02). Never re-prompt — the
 persisted marker is the engine choice.
 
 ### Optional Liveness Probe (GEM-05)
@@ -98,7 +98,7 @@ gemini -m <model-id> -p "ok" --approval-mode plan --skip-trust -o json 2>/dev/nu
 ```
 
 **Probe failure:** Fall back silently to
-[Claude Sub-Agent Refresh](#claude-sub-agent-refresh).
+[Claude Sub-Agent Refresh](#claude-sub-agent-refresh-build-02).
 
 ### Prepare the Delta Prompt
 
@@ -168,7 +168,7 @@ Capture `$DELTA_FINDINGS` as `<delta-findings>`. Check `$GEMINI_EXIT` and `$DELT
 
 ### Failure Conditions → Fallback
 
-Fall back silently to [Claude Sub-Agent Refresh](#claude-sub-agent-refresh) if
+Fall back silently to [Claude Sub-Agent Refresh](#claude-sub-agent-refresh-build-02) if
 any of:
 
 - `$GEMINI_EXIT` is non-zero (check before parsing — do not rely on the pipeline's `$?`).
@@ -178,7 +178,7 @@ any of:
 - `$DELTA_FINDINGS` is empty or whitespace-only.
 - `$DELTA_FINDINGS` contains none of the expected section headings.
 - `## Recent Changes` is absent from the delta.
-- Any top-level `## ` heading in the delta is not one of the expected headings
+- Any top-level `##` heading in the delta is not one of the expected headings
   (unrecognized or wrong case).
 
 ### Apply Delta
@@ -187,14 +187,14 @@ When `<delta-findings>` is valid, Claude (the parent skill, not a sub-agent)
 applies the delta directly:
 
 1. Read `.project/<slug>/docs/codebase-assessment.md` (current content).
-2. For each top-level `## ` heading in `<delta-findings>` (matched
-   byte-for-byte, including case and the `## ` prefix):
+2. For each top-level `##` heading in `<delta-findings>` (matched
+   byte-for-byte, including case and the `##` prefix):
    - Locate the matching heading in the current assessment.
    - If the heading is not found in the current assessment, fall back silently
-     to [Claude Sub-Agent Refresh](#claude-sub-agent-refresh) and abort the
+     to [Claude Sub-Agent Refresh](#claude-sub-agent-refresh-build-02) and abort the
      delta apply entirely.
-   - A section spans from its `## ` heading up to (but not including) the next
-     top-level `## ` heading or EOF. Nested `### ` and deeper headings are
+   - A section spans from its `##` heading up to (but not including) the next
+     top-level `##` heading or EOF. Nested `###` and deeper headings are
      part of that section.
    - Replace the entire section (heading + content) with the corresponding
      section from `<delta-findings>`.
@@ -269,10 +269,12 @@ regardless of the marker value.
 ## Standalone Commit (D-07)
 
 After the Gemini delta is applied or the Claude sub-agent completes, commit the updated assessment separately from
-any implementation commits:
+any implementation commits. Create it with the file-based helper — never a heredoc
+or multi-line `-m` (this refresh commit happens **before** the build loop loads the
+Commit Command Protocol in `build-execution.md`, so the rule applies here too):
 
-```
-docs(assessment): refresh codebase assessment for <feature-name>
+```bash
+bash .claude/scripts/gcommit "docs(assessment): refresh codebase assessment for <feature-name>"
 ```
 
 The commit covers `.project/<slug>/docs/codebase-assessment.md`.

--- a/skills/project/spike/SKILL.md
+++ b/skills/project/spike/SKILL.md
@@ -49,6 +49,7 @@ user to run `/project` to re-bootstrap.
 Gather the user's research question and available tooling list per
 D-05/SPIKE-01. If the user provided these in their invocation message, use
 them directly. If not provided, use `AskUserQuestion` to ask for:
+
 - Research question (what technical question to investigate)
 - Available tooling (libraries, tools, approaches to evaluate -- can be empty)
 
@@ -56,6 +57,7 @@ them directly. If not provided, use `AskUserQuestion` to ask for:
 Read `references/spike-format.md` for the Topic Slug Generation rules.
 Generate the slug from the topic. Check if
 `.project/{slug}/docs/spikes/{topic-slug}.md` exists on disk.
+
 - If file exists: enter follow-up mode (Step 5).
 - If file does not exist: enter new spike mode (Step 2).
 - If slug collision (file exists but different question): use
@@ -69,9 +71,11 @@ specification.
 
 Spawn a sub-agent using the `Agent` tool following the research agent spec.
 Pass the research question and available tooling list to the agent prompt.
-The agent writes findings to `/tmp/spike-research-findings.md`.
+The agent writes findings to `${TMPDIR:-/tmp}/spike-<slug>-research-findings.md` — substitute the actual
+spike `<slug>` (from Step 1) so concurrent spikes never collide on a shared temp file. Pass the
+concrete slug-filled path to the agent.
 
-After the agent completes, read `/tmp/spike-research-findings.md` to verify
+After the agent completes, read `${TMPDIR:-/tmp}/spike-<slug>-research-findings.md` to verify
 it was produced. If missing, report error and offer retry or manual input.
 
 ## Step 3 -- Red-Team Agent
@@ -80,10 +84,10 @@ Read `references/redteam-agent.md` for the complete red-team agent
 specification.
 
 Spawn a sub-agent using the `Agent` tool following the red-team agent spec.
-The agent reads `/tmp/spike-research-findings.md` (research output) and
-writes critique to `/tmp/spike-redteam-findings.md`.
+The agent reads `${TMPDIR:-/tmp}/spike-<slug>-research-findings.md` (research output) and
+writes critique to `${TMPDIR:-/tmp}/spike-<slug>-redteam-findings.md`.
 
-After the agent completes, read `/tmp/spike-redteam-findings.md` to verify
+After the agent completes, read `${TMPDIR:-/tmp}/spike-<slug>-redteam-findings.md` to verify
 it was produced. If missing, report error and offer retry.
 
 ## Step 4 -- Assemble Spike Artifact
@@ -92,6 +96,7 @@ Read `references/spike-format.md` for the artifact template and assembly
 instructions.
 
 Follow the assembly instructions to:
+
 1. Create `.project/{slug}/docs/spikes/` directory if it does not
    exist.
 2. Build the spike artifact using the New Spike Template.
@@ -121,6 +126,7 @@ agents (Steps 2-3) with the follow-up question as the research question
 and the same available tooling from the original spike.
 
 After both agents complete:
+
 1. Read the existing spike artifact from
    `.project/{slug}/docs/spikes/{topic-slug}.md`.
 2. Append a new Follow-Up Log entry per the dated entry format (per D-08,

--- a/skills/project/spike/references/redteam-agent.md
+++ b/skills/project/spike/references/redteam-agent.md
@@ -6,7 +6,7 @@ Spawned by `/spike` SKILL.md after the research agent completes (D-01). The red-
 
 The red-team agent receives:
 
-- **`/tmp/spike-research-findings.md`** -- the research agent's output (primary input to critique)
+- **`${TMPDIR:-/tmp}/spike-<slug>-research-findings.md`** -- the research agent's output (primary input to critique)
 - **`research_question`** -- the original question (for context on what was being investigated)
 - **`available_tooling`** -- the original tooling list (for context on what was in scope)
 
@@ -16,7 +16,7 @@ The red-team agent receives:
 
 Instruct the agent to:
 
-1. **Read `/tmp/spike-research-findings.md` thoroughly.** Understand the research agent's methodology, claims, and conclusions before beginning your critique.
+1. **Read `${TMPDIR:-/tmp}/spike-<slug>-research-findings.md` thoroughly.** Understand the research agent's methodology, claims, and conclusions before beginning your critique.
 
 2. **For each claim in the findings, attempt to verify or disprove using independent sources.** Do NOT rely solely on the research agent's sources. Use your own web searches and codebase analysis to check claims independently.
 
@@ -32,7 +32,7 @@ Instruct the agent to:
 
 5. **Use codebase tools** to cross-check compatibility claims against the actual project state (dependency versions, existing patterns, configuration).
 
-6. **Write structured critique** to `/tmp/spike-redteam-findings.md` with these sections:
+6. **Write structured critique** to `${TMPDIR:-/tmp}/spike-<slug>-redteam-findings.md` with these sections:
 
    ```
    # Red-Team Assessment
@@ -93,7 +93,7 @@ Same broad access as the research agent per D-03, enabling independent verificat
 
 ## Output
 
-The agent writes its critique to `/tmp/spike-redteam-findings.md`. The parent SKILL.md reads this file after agent completion and uses it to populate the Red-Team Assessment section of the spike artifact.
+The agent writes its critique to `${TMPDIR:-/tmp}/spike-<slug>-redteam-findings.md`. The parent SKILL.md reads this file after agent completion and uses it to populate the Red-Team Assessment section of the spike artifact.
 
 ## Confirmation Bias Prevention
 

--- a/skills/project/spike/references/research-agent.md
+++ b/skills/project/spike/references/research-agent.md
@@ -37,7 +37,7 @@ Instruct the agent to:
    - Find existing usage of related tools or patterns
    - Understand integration points where the evaluated tools would connect
 
-6. **Write structured findings** to `/tmp/spike-research-findings.md` with these sections:
+6. **Write structured findings** to `${TMPDIR:-/tmp}/spike-<slug>-research-findings.md` with these sections:
 
    ```
    # Research Findings
@@ -82,7 +82,7 @@ These tools allow documentation lookup via web search, codebase scanning for exi
 
 ## Output
 
-The agent writes its findings to `/tmp/spike-research-findings.md`. The parent SKILL.md reads this file after agent completion and uses it to populate the Methodology and Findings sections of the spike artifact.
+The agent writes its findings to `${TMPDIR:-/tmp}/spike-<slug>-research-findings.md`. The parent SKILL.md reads this file after agent completion and uses it to populate the Methodology and Findings sections of the spike artifact.
 
 ## Edge Cases
 

--- a/skills/project/spike/references/spike-format.md
+++ b/skills/project/spike/references/spike-format.md
@@ -39,10 +39,10 @@ The exact markdown template for a new spike artifact. All 8 sections are require
 <What the research agent investigated and how -- methodology from research findings>
 
 ## Findings
-<Research agent's discoveries, organized by sub-question or theme -- from /tmp/spike-research-findings.md>
+<Research agent's discoveries, organized by sub-question or theme -- from ${TMPDIR:-/tmp}/spike-<slug>-research-findings.md>
 
 ## Red-Team Assessment
-<Red-team agent's critique -- from /tmp/spike-redteam-findings.md. This is an EQUAL PEER section to Findings. Do not merge, summarize, or suppress any red-team concerns.>
+<Red-team agent's critique -- from ${TMPDIR:-/tmp}/spike-<slug>-redteam-findings.md. This is an EQUAL PEER section to Findings. Do not merge, summarize, or suppress any red-team concerns.>
 
 ## Recommendation
 <Clear pick with rationale. States the recommended approach, why it is recommended, what risks remain after red-team review, and conditions under which the recommendation should be revisited.>
@@ -57,8 +57,8 @@ open
 **Section notes:**
 
 - **Question** and **Available Tooling** are transcribed verbatim from user input (SPIKE-01).
-- **Methodology** and **Findings** are populated from `/tmp/spike-research-findings.md`.
-- **Red-Team Assessment** is populated from `/tmp/spike-redteam-findings.md`. Per D-10, this section is never edited, merged into Findings, or summarized. It stands as the red-team agent's independent output.
+- **Methodology** and **Findings** are populated from `${TMPDIR:-/tmp}/spike-<slug>-research-findings.md`.
+- **Red-Team Assessment** is populated from `${TMPDIR:-/tmp}/spike-<slug>-redteam-findings.md`. Per D-10, this section is never edited, merged into Findings, or summarized. It stands as the red-team agent's independent output.
 - **Recommendation** is synthesized by the parent SKILL.md after reading both agent outputs. Per D-11, it contains a clear pick with rationale, remaining risks, and revisitation conditions.
 - **Status** starts as `open` for all new spikes.
 - **Follow-Up Log** starts with the placeholder `(no follow-ups yet)`.
@@ -97,11 +97,11 @@ How the parent SKILL.md assembles the final spike artifact from agent outputs:
 
 1. **Create `.project/{project-slug}/docs/spikes/` directory** if it does not exist: `mkdir -p .project/{project-slug}/docs/spikes`
 
-2. **Read `/tmp/spike-research-findings.md`** for:
+2. **Read `${TMPDIR:-/tmp}/spike-<slug>-research-findings.md`** for:
    - Methodology section content (from the research agent's Methodology section)
    - Findings section content (from the research agent's Findings Summary and Per-Tool Analysis)
 
-3. **Read `/tmp/spike-redteam-findings.md`** for:
+3. **Read `${TMPDIR:-/tmp}/spike-<slug>-redteam-findings.md`** for:
    - Red-Team Assessment section content (use the full red-team output -- do not summarize or filter)
 
 4. **Write the Recommendation section** by synthesizing both agent outputs:
@@ -116,7 +116,7 @@ How the parent SKILL.md assembles the final spike artifact from agent outputs:
 
 7. **Write the complete artifact** to `.project/{project-slug}/docs/spikes/<topic-slug>.md` using the New Spike Template
 
-8. **Clean up temp files:** Remove `/tmp/spike-research-findings.md` and `/tmp/spike-redteam-findings.md`
+8. **Clean up temp files:** Remove `${TMPDIR:-/tmp}/spike-<slug>-research-findings.md` and `${TMPDIR:-/tmp}/spike-<slug>-redteam-findings.md`
 
 ## Resolution
 
@@ -125,13 +125,17 @@ Per D-07 and SPIKE-06, when the user signals that a spike is resolved:
 1. **Update the spike artifact:** Change `## Status` from `open` to `resolved`
 
 2. **Update progress.txt:** Change the spike entry from:
+
    ```
    [ ] Spike Name  .project/{project-slug}/docs/spikes/<topic>.md
    ```
+
    to:
+
    ```
    [x] Spike Name  .project/{project-slug}/docs/spikes/<topic>.md  Resolved: YYYY-MM-DD
    ```
+
    where `YYYY-MM-DD` is the current date.
 
 3. Resolution is a user-initiated action -- the skill never auto-resolves a spike. After each follow-up, the skill offers the user an option to resolve (D-08).

--- a/tests/installer-claude-toolkit.bats
+++ b/tests/installer-claude-toolkit.bats
@@ -1,0 +1,214 @@
+#!/usr/bin/env bats
+# tests/installer-claude-toolkit.bats — claude-toolkit installer behavior tests
+# Run: bats tests/installer-claude-toolkit.bats  (from project root)
+# Requires: bats-core, jq, node
+
+INSTALLER="$BATS_TEST_DIRNAME/../scripts/claude-toolkit/install.sh"
+
+setup() {
+  TARGET="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TARGET"
+}
+
+# ── Fresh install ─────────────────────────────────────────────────────────────
+
+@test "scripts copied to .claude/scripts/ on fresh install" {
+  bash "$INSTALLER" "$TARGET"
+  [ -f "$TARGET/.claude/scripts/gcommit" ]
+  [ -f "$TARGET/.claude/scripts/branch-sync.sh" ]
+  [ -f "$TARGET/.claude/scripts/codex-review.sh" ]
+  [ -f "$TARGET/.claude/scripts/run-quiet.sh" ]
+  [ -f "$TARGET/.claude/scripts/state-status.sh" ]
+  [ -f "$TARGET/.claude/scripts/check.sh" ]
+}
+
+@test "hooks copied to .claude/hooks/ on fresh install" {
+  bash "$INSTALLER" "$TARGET"
+  [ -f "$TARGET/.claude/hooks/block-heredoc-commit.js" ]
+  [ -f "$TARGET/.claude/hooks/lint-md-on-edit.js" ]
+}
+
+@test "no executable bits set on installed files" {
+  bash "$INSTALLER" "$TARGET"
+  local f
+  for f in "$TARGET/.claude/scripts/"* "$TARGET/.claude/hooks/"*; do
+    [ ! -x "$f" ]
+  done
+}
+
+@test "both hook markers present in settings.json after fresh install" {
+  bash "$INSTALLER" "$TARGET"
+  local settings="$TARGET/.claude/settings.json"
+  jq -e '[.. | objects | .command? // empty | select(type=="string" and contains("cc-toolkit-heredoc-block"))] | length > 0' \
+    "$settings" >/dev/null
+  jq -e '[.. | objects | .command? // empty | select(type=="string" and contains("cc-toolkit-lint-md"))] | length > 0' \
+    "$settings" >/dev/null
+}
+
+@test "settings.json remains valid JSON after merge" {
+  bash "$INSTALLER" "$TARGET"
+  jq empty "$TARGET/.claude/settings.json"
+}
+
+@test "heredoc hook entry has timeout 5 and a statusMessage" {
+  bash "$INSTALLER" "$TARGET"
+  local settings="$TARGET/.claude/settings.json"
+  jq -e '[.hooks.PreToolUse[].hooks[] | select(.command | contains("cc-toolkit-heredoc-block"))
+          | select(.timeout == 5 and (.statusMessage | length > 0))] | length == 1' \
+    "$settings" >/dev/null
+}
+
+@test "lint-md hook entry has timeout 15 and a statusMessage" {
+  bash "$INSTALLER" "$TARGET"
+  local settings="$TARGET/.claude/settings.json"
+  jq -e '[.hooks.PostToolUse[].hooks[] | select(.command | contains("cc-toolkit-lint-md"))
+          | select(.timeout == 15 and (.statusMessage | length > 0))] | length == 1' \
+    "$settings" >/dev/null
+}
+
+@test "pre-existing settings.json keys survive the merge" {
+  mkdir -p "$TARGET/.claude"
+  printf '{"model":"opus","permissions":{"allow":["Bash(ls:*)"]},"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo pre-existing"}]}]}}' \
+    > "$TARGET/.claude/settings.json"
+  bash "$INSTALLER" "$TARGET"
+  local settings="$TARGET/.claude/settings.json"
+  [ "$(jq -r '.model' "$settings")" = "opus" ]
+  [ "$(jq -r '.permissions.allow[0]' "$settings")" = "Bash(ls:*)" ]
+  jq -e '[.. | objects | .command? // empty | select(type=="string" and contains("echo pre-existing"))] | length == 1' \
+    "$settings" >/dev/null
+}
+
+@test "migration — unmarked hand-wired hook entries are replaced, not duplicated" {
+  # Seed the exact shape a consumer repo used before this installer existed:
+  # both hooks wired by hand, no idempotency markers.
+  mkdir -p "$TARGET/.claude"
+  cat > "$TARGET/.claude/settings.json" << 'EOF'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-heredoc-commit.js\"",
+            "timeout": 5,
+            "statusMessage": "Checking commit style..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/lint-md-on-edit.js\"",
+            "timeout": 15,
+            "statusMessage": "Formatting markdown..."
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+  bash "$INSTALLER" "$TARGET"
+  local settings="$TARGET/.claude/settings.json"
+  # exactly one entry per hook script, and it carries the marker
+  [ "$(jq '[.. | objects | .command? // empty | select(type=="string" and contains("block-heredoc-commit.js"))] | length' "$settings")" -eq 1 ]
+  [ "$(jq '[.. | objects | .command? // empty | select(type=="string" and contains("lint-md-on-edit.js"))] | length' "$settings")" -eq 1 ]
+  jq -e '[.. | objects | .command? // empty | select(type=="string" and contains("cc-toolkit-heredoc-block"))] | length == 1' \
+    "$settings" >/dev/null
+  jq -e '[.. | objects | .command? // empty | select(type=="string" and contains("cc-toolkit-lint-md"))] | length == 1' \
+    "$settings" >/dev/null
+}
+
+# ── CLAUDE.md sentinel ────────────────────────────────────────────────────────
+
+@test "CLAUDE.md sentinel pair present after fresh install" {
+  bash "$INSTALLER" "$TARGET"
+  grep -qF '<!-- BEGIN CLAUDE-TOOLKIT -->' "$TARGET/CLAUDE.md"
+  grep -qF '<!-- END CLAUDE-TOOLKIT -->'   "$TARGET/CLAUDE.md"
+}
+
+@test "pre-existing CLAUDE.md content is appended to, not clobbered" {
+  printf '# My Project\n\nHand-written guidance.\n' > "$TARGET/CLAUDE.md"
+  bash "$INSTALLER" "$TARGET"
+  grep -qF 'Hand-written guidance.' "$TARGET/CLAUDE.md"
+  grep -qF '<!-- BEGIN CLAUDE-TOOLKIT -->' "$TARGET/CLAUDE.md"
+}
+
+@test "malformed sentinel (BEGIN without END) fails the install" {
+  printf '# My Project\n\n<!-- BEGIN CLAUDE-TOOLKIT -->\npartial block, no end\n' > "$TARGET/CLAUDE.md"
+  run bash "$INSTALLER" "$TARGET"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"malformed"* ]]
+}
+
+# ── .cc-base-branch semantics ─────────────────────────────────────────────────
+
+@test "--base-branch writes .cc-base-branch when absent" {
+  bash "$INSTALLER" --base-branch develop "$TARGET"
+  [ -f "$TARGET/.cc-base-branch" ]
+  [ "$(head -n1 "$TARGET/.cc-base-branch")" = "develop" ]
+}
+
+@test "without --base-branch no .cc-base-branch is written" {
+  bash "$INSTALLER" "$TARGET"
+  [ ! -f "$TARGET/.cc-base-branch" ]
+}
+
+@test "--base-branch leaves a pre-existing differing .cc-base-branch untouched" {
+  printf 'main\n' > "$TARGET/.cc-base-branch"
+  bash "$INSTALLER" --base-branch develop "$TARGET"
+  [ "$(head -n1 "$TARGET/.cc-base-branch")" = "main" ]
+}
+
+# ── Idempotency ───────────────────────────────────────────────────────────────
+
+@test "idempotent — second run does not duplicate hook markers" {
+  bash "$INSTALLER" "$TARGET"
+  bash "$INSTALLER" "$TARGET"
+  local settings="$TARGET/.claude/settings.json"
+  [ "$(jq '[.. | objects | .command? // empty | select(type=="string" and contains("cc-toolkit-heredoc-block"))] | length' "$settings")" -eq 1 ]
+  [ "$(jq '[.. | objects | .command? // empty | select(type=="string" and contains("cc-toolkit-lint-md"))] | length' "$settings")" -eq 1 ]
+}
+
+@test "idempotent — second run does not duplicate CLAUDE.md sentinel" {
+  bash "$INSTALLER" "$TARGET"
+  bash "$INSTALLER" "$TARGET"
+  [ "$(grep -cF '<!-- BEGIN CLAUDE-TOOLKIT -->' "$TARGET/CLAUDE.md")" -eq 1 ]
+}
+
+@test "idempotent — second run produces empty diff on settings.json and CLAUDE.md" {
+  bash "$INSTALLER" "$TARGET"
+  local snap
+  snap="$(mktemp -d)"
+  cp "$TARGET/.claude/settings.json" "$snap/settings.json"
+  cp "$TARGET/CLAUDE.md"             "$snap/CLAUDE.md"
+
+  bash "$INSTALLER" "$TARGET"
+
+  diff "$snap/settings.json" "$TARGET/.claude/settings.json"
+  diff "$snap/CLAUDE.md"     "$TARGET/CLAUDE.md"
+  rm -rf "$snap"
+}
+
+# ── Bundle + installed self-test ──────────────────────────────────────────────
+
+@test "bundle self-test (check.sh) passes in bundle layout" {
+  # node is a hard prereq of the installer; check.sh needs it too — no skip.
+  run bash "$BATS_TEST_DIRNAME/../scripts/claude-toolkit/check.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "installed self-test (check.sh) passes in installed layout" {
+  bash "$INSTALLER" "$TARGET"
+  run bash "$TARGET/.claude/scripts/check.sh"
+  [ "$status" -eq 0 ]
+}

--- a/tests/installer-claude-toolkit.bats
+++ b/tests/installer-claude-toolkit.bats
@@ -31,6 +31,59 @@ teardown() {
   [ -f "$TARGET/.claude/hooks/lint-md-on-edit.js" ]
 }
 
+@test "project suite installed FLAT — every SKILL.md exactly one level deep" {
+  bash "$INSTALLER" "$TARGET"
+  local s="$TARGET/.claude/skills"
+  # Claude Code scans .claude/skills/ one level deep and derives the command
+  # from the directory name, so each skill must be at <skills>/<name>/SKILL.md.
+  for name in project build define design milestone plan-feature spike; do
+    [ -f "$s/$name/SKILL.md" ]
+  done
+  # No SKILL.md deeper than one level (would be undiscoverable).
+  run bash -c "find '$s' -mindepth 3 -name SKILL.md | wc -l | tr -d ' '"
+  [ "$output" -eq 0 ]
+}
+
+@test "orchestrator directory carries no nested sub-skill copies" {
+  bash "$INSTALLER" "$TARGET"
+  for name in build define design milestone plan-feature spike; do
+    [ ! -e "$TARGET/.claude/skills/project/$name" ]
+  done
+  [ -f "$TARGET/.claude/skills/project/SKILL.md" ]
+}
+
+@test "skill resource directories are copied with the bundle" {
+  bash "$INSTALLER" "$TARGET"
+  [ -d "$TARGET/.claude/skills/build/references" ]
+  [ -f "$TARGET/.claude/skills/build/references/build-execution.md" ]
+}
+
+@test "--no-skills installs scripts and hooks only" {
+  bash "$INSTALLER" --no-skills "$TARGET"
+  [ ! -d "$TARGET/.claude/skills" ]
+  [ -f "$TARGET/.claude/scripts/gcommit" ]
+  [ -f "$TARGET/.claude/hooks/lint-md-on-edit.js" ]
+}
+
+@test "idempotent — second run reports skills unchanged and leaves no temp dirs" {
+  bash "$INSTALLER" "$TARGET"
+  run bash "$INSTALLER" "$TARGET"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"unchanged project"* ]]
+  [[ "$output" == *"unchanged build"* ]]
+  [[ "$output" != *"updated build"* ]]
+  run bash -c "ls '${TMPDIR:-/tmp}' | grep -c 'cc-toolkit-project' || true"
+  [ "$output" -eq 0 ]
+}
+
+@test "skill overlay preserves consumer-added files" {
+  bash "$INSTALLER" "$TARGET"
+  printf 'local note\n' > "$TARGET/.claude/skills/build/LOCAL-NOTES.md"
+  bash "$INSTALLER" "$TARGET"
+  [ -f "$TARGET/.claude/skills/build/LOCAL-NOTES.md" ]
+  [ -f "$TARGET/.claude/skills/build/SKILL.md" ]
+}
+
 @test "no executable bits set on installed files" {
   bash "$INSTALLER" "$TARGET"
   local f

--- a/tests/installer-claude-toolkit.bats
+++ b/tests/installer-claude-toolkit.bats
@@ -143,6 +143,18 @@ EOF
   grep -qF '<!-- BEGIN CLAUDE-TOOLKIT -->' "$TARGET/CLAUDE.md"
 }
 
+@test "wrong-typed .hooks[event] fails with a clear error and leaves no temp files" {
+  mkdir -p "$TARGET/.claude"
+  printf '{"hooks":{"PreToolUse":{"bad":"hand-edit"}}}' > "$TARGET/.claude/settings.json"
+  run bash "$INSTALLER" "$TARGET"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"array is required"* ]]
+  # settings.json untouched, and no settings.json.XXXXXX left behind
+  [ "$(jq -r '.hooks.PreToolUse.bad' "$TARGET/.claude/settings.json")" = "hand-edit" ]
+  run bash -c "ls '$TARGET/.claude/' | grep -c 'settings\.json\.'"
+  [ "$output" -eq 0 ]
+}
+
 @test "malformed sentinel (BEGIN without END) fails the install" {
   printf '# My Project\n\n<!-- BEGIN CLAUDE-TOOLKIT -->\npartial block, no end\n' > "$TARGET/CLAUDE.md"
   run bash "$INSTALLER" "$TARGET"


### PR DESCRIPTION
## Summary

Upstreams the Claude Code toolkit refinements battle-tested in `occ-k8s-cluster-config` (weeks of live use on a production GitOps repo) back into this template library, as root templates. Merge policy: **newest-wins per file**, diff-verified in both directions.

## Merge map

**K8s → here (adopted):**

- `skills/project/SKILL.md` — light-schema guard (won't parse/overwrite a `/create-prd` progress.txt)
- `skills/create-prd/SKILL.md` — coexistence guard against gated `/project` state
- `skills/project/build/references/build-execution.md` — read-once loop context efficiency + Commit Command Protocol D-03 (`gcommit`)
- `skills/project/build/references/codebase-refresh.md` — D-07 assessment commit via `gcommit` (fires before D-03 loads); also fixed pre-existing broken anchors
- `commands/start-feature-auto.md` — Steps 7–9: Codex review (exit 2 ≠ PASS), VALID/REJECTED triage, conditional refactor
- `rules/agent-delegation.md` — routing table rewritten to real spawnable agents + plugin-availability fallbacks
- `skills/project/spike/*` — slug-namespaced `${TMPDIR:-/tmp}` sub-agent temp files (concurrency-safe)

**Here is newer (retained, NOT overwritten):**

- Gemini GEM-01..08 scan feature (`gate-0-codebase.md`, `codebase-refresh.md`)
- `rules/defensive-protocol-v2-anti-slop.md` (event-driven verification)
- `defensive-protocol-v2-epistemology.md` (identical both sides)

**Not ported:** k8s consumer-specific CLAUDE.md guidance (SSH aliases, cluster IPs, ArgoCD URLs), whitespace-only autofix drift.

## New: `scripts/claude-toolkit/` bundle

Six scripts (`gcommit`, `branch-sync.sh`, `codex-review.sh`, `run-quiet.sh`, `state-status.sh`, `check.sh`) + two node hooks (`block-heredoc-commit.js`, `lint-md-on-edit.js`) + `install.sh` following the defensive-protocol installer idiom, extended with: node hard prereq, timeout/statusMessage on hook entries, **migration of pre-existing unmarked hook entries** (no duplicates on already-hand-wired consumers), malformed-sentinel hard-fail, opt-in `--base-branch` pinning. `assets/eslint.config.mjs` ships as a manual-copy asset.

## Docs

Two-tier per convention: SCRIPTS/COMMANDS/RULES/SKILLS indexes updated; new `docs/scripts/claude-toolkit/REFERENCE.md`; new `docs/skills/red-team.md` (was missing); five Tier-2 pages regenerated/updated. Drift fixed: stale `/create-prd` consuming guidance, missing red-team entries.

## Verification

- `bash scripts/claude-toolkit/check.sh` — 29/29 fixtures (bundle + installed layouts)
- `bats tests/installer-claude-toolkit.bats` — 20/20 (incl. unmarked-entry migration fixture seeded with the real k8s `settings.json` shape)
- `bats tests/installer-over-engineering.bats` — 8/8 (no regression)
- Smoke installs: clean target + target seeded with the actual k8s settings.json → exactly one entry per hook
- markdownlint (enforcing config): 0 errors across all 22 touched files
- Diff-back vs SRC: only intended deltas (CWD note, plugin paragraph, TMPDIR genericization); Gemini content intact

## Follow-ups (out of scope)

- README.md lacks agent-profiles/codex-skills sections; references nonexistent `kiro/README.md`
- `docs/SCRIPTS.md` "View" links for agent-delegation/defensive-protocol point at nonexistent `docs/scripts/` pages
- Slash `/project` suite has no Tier-2 page (`docs/skills/project.md` documents the Codex variant)
- Plan reviewed by Codex pre-implementation; all 4 MED findings addressed in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
